### PR TITLE
Uncheck torch toggle on instances camera is restarted

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -225,6 +225,7 @@ class SettingsDialog(mActivity: MainActivity) : Dialog(mActivity, R.style.Theme_
 
         includeAudioToggle = findViewById(R.id.include_audio_switch)
         includeAudioToggle.setOnCheckedChangeListener { _, _ ->
+            torchToggle.isChecked = false
             mActivity.config.startCamera(true)
         }
     }


### PR DESCRIPTION
Changing video quality, image quality, and emphasis on options restart camera, then turns off flash. The torch toggle UI was not updated accordingly, and this patch fixes this UI issue.