### PR TITLE
Uncheck torch button when camera is force started

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/config/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/config/CamConfig.kt
@@ -485,6 +485,9 @@ class CamConfig(private val mActivity: MainActivity) : SettingsConfig() {
         if (!forced && camera != null) return
 
         updatePrefMode()
+        if (mActivity.settingsDialog.torchToggle.isChecked) {
+            mActivity.settingsDialog.torchToggle.isChecked = false
+        }
 
         val rotation = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
             val display = mActivity.display

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -27,7 +27,7 @@ class SettingsDialog(mActivity: MainActivity) : Dialog(mActivity, R.style.Theme_
     var locToggle: ToggleButton
     var flashToggle: ImageView
     var aRToggle: ToggleButton
-    private var torchToggle: ToggleButton
+    var torchToggle: ToggleButton
     private var gridToggle: ImageView
     private var mActivity: MainActivity
     var videoQualitySpinner : Spinner


### PR DESCRIPTION
As the torch turns off when the camera (re)starts, show a consistent UI where it is unchecked