### PR TITLE
[Bug Fix] place setting icon correctly

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -14,6 +14,7 @@ import android.content.pm.PackageManager
 import android.database.ContentObserver
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.Point
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Build
@@ -83,6 +84,8 @@ import android.graphics.Rect
 import android.view.ViewTreeObserver
 import app.grapheneos.camera.ui.QRToggle
 import com.google.zxing.BarcodeFormat
+import android.view.WindowInsets
+import android.widget.RelativeLayout
 
 
 open class MainActivity : AppCompatActivity(),
@@ -775,6 +778,32 @@ open class MainActivity : AppCompatActivity(),
             if (!config.isQRMode)
                 settingsDialog.show()
         }
+
+        settingsIcon.viewTreeObserver.addOnGlobalLayoutListener(
+            object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    rootView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    val displayCutout = window.decorView.rootWindowInsets.displayCutout
+                    val layoutParams = (settingsIcon.layoutParams as RelativeLayout.LayoutParams)
+
+                    val rect = if (displayCutout?.boundingRects?.isNotEmpty() == true)
+                        displayCutout.boundingRects.first() else null
+                    
+                    val windowsSize = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        windowManager.currentWindowMetrics.bounds
+                    } else {
+                        val size = Point()
+                        windowManager.defaultDisplay.getRealSize(size)
+                        Rect(0, 0, size.x, size.y)
+                    }
+
+                    if(rect == null || rect.left == 0 || rect.right == windowsSize.right){
+                        layoutParams.addRule(RelativeLayout.CENTER_HORIZONTAL)
+                    } else{
+                        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+                    }
+                }
+            })
 
         exposurePlusIcon = findViewById(R.id.exposure_plus_icon)
         exposureNegIcon = findViewById(R.id.exposure_neg_icon)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -372,11 +372,12 @@
 
         <ImageButton
             android:id="@+id/settings_option"
-            android:layout_centerHorizontal="true"
             android:layout_alignParentTop="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
+            tools:visibility="visible"
+            android:paddingHorizontal="16dp"
             android:background="@null"
             android:src="@drawable/settings_icon"
             android:layout_marginTop="16dp"


### PR DESCRIPTION
Few people reported settings icon is underneath the camera cutout in pixel 6 which make it invisible/harder to find.

This is solution for the same, by positioning icon according to notch.