### PR TITLE
Set keepScreenOn to true to prevent screen timeout when camera preview is active

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,6 +29,7 @@
                     android:id="@+id/preview"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:keepScreenOn="true"
                     app:layout_constraintDimensionRatio="H,9:16"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
This covers QR scanning, Camera, and Video modes.

Solves https://github.com/GrapheneOS/Camera/issues/105