### PR TITLE
Target SDK 12L/12.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         applicationId = "app.grapheneos.camera"
         minSdk = 29
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 16
         versionName = versionCode.toString()
     }


### PR DESCRIPTION
GrapheneOS is now on 12.1

Signed-off-by: June <june@eridan.me>