### PR TITLE
Fix exception at scan result dialog inflation

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="qr_result_background">@color/material_dynamic_neutral20</color>
+    <color name="qr_result_background">#2E3133</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,5 +17,5 @@
 
     <color name="z_yellow">#ffdf00</color>
 
-    <color name="qr_result_background">@color/material_dynamic_neutral90</color>
+    <color name="qr_result_background">#E1E3E5</color>
 </resources>


### PR DESCRIPTION
Use static instead of dynamic color for the QR result background,
because dynamic colors might not always be available.