### PR TITLE
Proper countdown timer text colour and hide timer in QR mode

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -1584,7 +1584,7 @@ class CamConfig(private val mActivity: MainActivity) {
             }
         }
 
-        mActivity.cbText.visibility = if (isVideoMode || mActivity.timerDuration == 0) {
+        mActivity.cbText.visibility = if (isQRMode || isVideoMode || mActivity.timerDuration == 0) {
             View.INVISIBLE
         } else {
             View.VISIBLE

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -235,6 +235,7 @@
                     android:layout_gravity="center"
                     android:textSize="28dp"
                     android:textStyle="bold"
+                    android:textColor="#333"
                     tools:ignore="SpUsage"/>
 
                 <ImageView


### PR DESCRIPTION
`#333` (dark grey) was picked because the original is white text on white and pure black (`#000`) text on pure white (`#FFF`) is too harsh for the eye.