### PR TITLE
Increase field of view for devices with default video stabilization

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
+import android.hardware.camera2.CameraMetadata
+import android.hardware.camera2.CaptureRequest
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
@@ -21,6 +23,7 @@ import android.view.animation.LinearInterpolator
 import android.widget.Button
 import android.widget.FrameLayout
 import androidx.annotation.StringRes
+import androidx.camera.camera2.interop.Camera2Interop
 import androidx.camera.core.AspectRatio
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
@@ -1302,13 +1305,23 @@ class CamConfig(private val mActivity: MainActivity) {
             }
         }
 
-        preview = Preview.Builder()
+        var previewBuilder = Preview.Builder()
             .setTargetRotation(
                 preview?.targetRotation
                     ?: rotation
             )
-            .setTargetAspectRatio(aspectRatio)
-            .build()
+            .setTargetAspectRatio(aspectRatio);
+
+        @androidx.camera.camera2.interop.ExperimentalCamera2Interop
+        if (!isVideoMode) {
+            Camera2Interop.Extender(previewBuilder)
+                .setCaptureRequestOption(
+                    CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,
+                    CameraMetadata.CONTROL_VIDEO_STABILIZATION_MODE_OFF
+                )
+        }
+
+        preview = previewBuilder.build()
 
         preview?.let {
             useCaseGroupBuilder.addUseCase(it)


### PR DESCRIPTION
Digital video stabilization reduces the field of view to provide a
buffer to move the target area around within. This mode does not
make sense for static images, therefore deactivate this mode.

Reference: https://issuetracker.google.com/issues/230013960?pli=1

Signed-off-by: Adam Serbinski <adam@serbinski.com>