### PR TITLE
bugfix: loading EXIF data from an arbitrary InputStream was broken

### DIFF
--- a/app/src/main/java/androidxc/exifinterface/media/ExifInterface.java
+++ b/app/src/main/java/androidxc/exifinterface/media/ExifInterface.java
@@ -4578,6 +4578,10 @@ public class ExifInterface {
 
             // Check file type
             if (!mIsExifDataOnly) {
+                if (!(in instanceof ByteArrayInputStream)) {
+                    in = new BufferedInputStream(in, SIGNATURE_CHECK_SIZE);
+                }
+
                 mMimeType = getMimeType(in);
             }
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Camera/issues/214