### PR TITLE
Move camera sounds toggle to More Settings

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -87,7 +87,6 @@ class CamConfig(private val mActivity: MainActivity) {
             const val GRID = "grid"
             const val EMPHASIS_ON_QUALITY = "emphasis_on_quality"
             const val FOCUS_TIMEOUT = "focus_timeout"
-            const val CAMERA_SOUNDS = "camera_sounds"
             const val VIDEO_QUALITY = "video_quality"
             const val ASPECT_RATIO = "aspect_ratio"
             const val INCLUDE_AUDIO = "include_audio"
@@ -104,6 +103,8 @@ class CamConfig(private val mActivity: MainActivity) {
             const val REMOVE_EXIF_AFTER_CAPTURE = "remove_exif_after_capture"
 
             const val GYROSCOPE_SUGGESTIONS = "gyroscope_suggestions"
+
+            const val CAMERA_SOUNDS = "camera_sounds"
 
             // const val IMAGE_FILE_FORMAT = "image_quality"
             // const val VIDEO_FILE_FORMAT = "video_quality"
@@ -126,8 +127,6 @@ class CamConfig(private val mActivity: MainActivity) {
 
             const val FOCUS_TIMEOUT = "5s"
 
-            const val CAMERA_SOUNDS = true
-
             const val INCLUDE_AUDIO = true
 
             const val ENABLE_EIS = true
@@ -144,6 +143,8 @@ class CamConfig(private val mActivity: MainActivity) {
             const val REMOVE_EXIF_AFTER_CAPTURE = true
 
             const val GYROSCOPE_SUGGESTIONS = false
+
+            const val CAMERA_SOUNDS = true
 
             // const val IMAGE_FILE_FORMAT = ""
             // const val VIDEO_FILE_FORMAT = ""
@@ -398,14 +399,15 @@ class CamConfig(private val mActivity: MainActivity) {
 
     var enableCameraSounds: Boolean
         get() {
-            return mActivity.settingsDialog.csSwitch.isChecked
+            return commonPref.getBoolean(
+                SettingValues.Key.CAMERA_SOUNDS,
+                SettingValues.Default.CAMERA_SOUNDS
+            )
         }
         set(value) {
             val editor = commonPref.edit()
             editor.putBoolean(SettingValues.Key.CAMERA_SOUNDS, value)
             editor.apply()
-
-            mActivity.settingsDialog.csSwitch.isChecked = value
         }
 
     var scanAllCodes: Boolean
@@ -955,12 +957,6 @@ class CamConfig(private val mActivity: MainActivity) {
 
 
         editor.commit()
-
-        mActivity.settingsDialog.csSwitch.isChecked =
-            commonPref.getBoolean(
-                SettingValues.Key.CAMERA_SOUNDS,
-                SettingValues.Default.CAMERA_SOUNDS
-            )
 
         gridType = GridType.values()[commonPref.getInt(
             SettingValues.Key.GRID,

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -73,7 +73,6 @@ class SettingsDialog(val mActivity: MainActivity) :
     var enableEISToggle: SwitchCompat
 
     var selfIlluminationToggle: SwitchCompat
-    var csSwitch: SwitchCompat
 
     private val timeOptions = mActivity.resources.getStringArray(R.array.time_options)
 
@@ -328,11 +327,6 @@ class SettingsDialog(val mActivity: MainActivity) :
 
         mScrollView = binding.settingsScrollview
         mScrollViewContent = binding.settingsScrollviewContent
-
-        csSwitch = binding.cameraSoundsSwitch
-        csSwitch.setOnCheckedChangeListener { _, value ->
-            camConfig.enableCameraSounds = value
-        }
 
         includeAudioSetting = binding.includeAudioSetting
         enableEISSetting = binding.enableEisSetting

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
@@ -234,6 +234,17 @@ class MoreSettings : AppCompatActivity(), TextView.OnEditorActionListener {
             gSwitch.performClick()
         }
 
+        val csSwitch = binding.cameraSoundsSwitch
+        csSwitch.isChecked = camConfig.enableCameraSounds
+        csSwitch.setOnClickListener {
+            camConfig.enableCameraSounds = csSwitch.isChecked
+        }
+
+        val csSetting = binding.cameraSoundsSetting
+        csSetting.setOnClickListener {
+            csSwitch.performClick()
+        }
+
         val sIAPSetting = binding.saveImageAsPreviewSetting
         sIAPSetting.setOnClickListener {
             sIAPToggle.performClick()

--- a/app/src/main/res/drawable/volume_up.xml
+++ b/app/src/main/res/drawable/volume_up.xml
@@ -1,0 +1,13 @@
+<vector
+    android:height="24dp"
+    android:tint="?android:textColorPrimary"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <path
+        android:fillColor="?android:textColorPrimary"
+        android:pathData="M3,10v4c0,0.55 0.45,1 1,1h3l3.29,3.29c0.63,0.63 1.71,0.18 1.71,-0.71L12,6.41c0,-0.89 -1.08,-1.34 -1.71,-0.71L7,9L4,9c-0.55,0 -1,0.45 -1,1zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,4.45v0.2c0,0.38 0.25,0.71 0.6,0.85C17.18,6.53 19,9.06 19,12s-1.82,5.47 -4.4,6.5c-0.36,0.14 -0.6,0.47 -0.6,0.85v0.2c0,0.63 0.63,1.07 1.21,0.85C18.6,19.11 21,15.84 21,12s-2.4,-7.11 -5.79,-8.4c-0.58,-0.23 -1.21,0.22 -1.21,0.85z"/>
+
+</vector>

--- a/app/src/main/res/layout/more_settings.xml
+++ b/app/src/main/res/layout/more_settings.xml
@@ -84,6 +84,65 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/camera_sounds_setting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="?android:attr/selectableItemBackground"
+            android:paddingTop="8dp"
+            android:paddingBottom="10dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="6dp"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ImageView
+                android:id="@+id/camera_sounds_icon"
+                android:src="@drawable/volume_up"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:contentDescription="@string/camera_sounds"
+                android:paddingStart="4dp"
+                android:paddingEnd="8dp"/>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/camera_sounds_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/camera_sounds"
+                    android:layout_marginStart="10dp"
+                    android:paddingBottom="2dp"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="16sp"/>
+
+                <TextView
+                    android:id="@+id/camera_sounds_description"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/camera_sounds_desc"
+                    android:paddingStart="10dp"
+                    android:textSize="14sp"
+                    tools:ignore="RtlSymmetry"/>
+
+            </LinearLayout>
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/camera_sounds_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|center_vertical"
+                android:layout_marginEnd="0dp"/>
+
+        </LinearLayout>
+
         <TextView
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -228,28 +228,6 @@
                     </LinearLayout>
 
                     <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:paddingVertical="@dimen/settings_dialog_menu_item_vertical"
-                        android:paddingHorizontal="@dimen/settings_dialog_menu_item_horizontal"
-                        android:orientation="horizontal">
-
-                        <TextView
-                            android:layout_height="wrap_content"
-                            android:layout_width="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:text="@string/camera_sounds"/>
-
-                        <androidx.appcompat.widget.SwitchCompat
-                            android:id="@+id/camera_sounds_switch"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:checked="true"
-                            android:layout_gravity="end"/>
-
-                    </LinearLayout>
-
-                    <LinearLayout
                         android:id="@+id/enable_eis_setting"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,6 @@
     <string name="focus_timeout">Focus Timeout</string>
     <string name="timer">Timer</string>
     <string name="cancel_timer">Cancel Timer</string>
-    <string name="camera_sounds">Camera Sounds</string>
     <string name="video_capture_label">Record Video</string>
 
     <string name="camera">CAMERA</string>
@@ -75,6 +74,9 @@
 
     <string name="gyroscope_suggestions">Gyroscope Suggestions</string>
     <string name="gyroscope_setting_desc">Occasionally get visual suggestions for straight/well-angled images</string>
+
+    <string name="camera_sounds">Camera Sounds</string>
+    <string name="camera_sounds_desc">Shutter sound and other audio cues</string>
 
     <string name="storage">Storage</string>
     <string name="storage_location">Storage Location</string>


### PR DESCRIPTION
With the addition of the EIS toggle, the quick settings list is growing large in video mode. More specifically, when the front camera is in use and the self illumination toggle becomes visible, the settings list now requires scrolling. This is undesirable in a quick settings menu.

I think this setting makes the most sense to move as I can't imagine many users needing to constantly change it.