### PR TITLE
Add workaround for devices with broken region focus support

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -191,10 +191,22 @@ open class MainActivity : AppCompatActivity(),
             previewView.width.toFloat(), previewView.height.toFloat()
         )
 
-        val autoFocusPoint = factory.createPoint(
-            previewView.width / 2.0f,
-            previewView.height / 2.0f, qrOverlay.size
-        )
+        val shouldUseFocusRegion = when (Build.PRODUCT) {
+            "OnePlus6", "OnePlus6T" -> false
+            else -> true
+        }
+
+        val autoFocusPoint = if (shouldUseFocusRegion) {
+            factory.createPoint(
+                previewView.width / 2.0f,
+                previewView.height / 2.0f, qrOverlay.size
+            )
+        } else {
+            factory.createPoint(
+                previewView.width / 2.0f,
+                previewView.height / 2.0f
+            )
+        }
 
         camConfig.camera?.cameraControl?.startFocusAndMetering(
             FocusMeteringAction.Builder(autoFocusPoint).disableAutoCancel().build()


### PR DESCRIPTION
In this case the OnePlus 6 and 6T

Closes https://github.com/GrapheneOS/Camera/issues/204