### PR TITLE
Build against android 13 APIs and migrate most deprecated APIs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
     implementation("com.google.android.material:material:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
-    val cameraVersion = "1.2.0-alpha02"
+    val cameraVersion = "1.2.0-alpha03"
     implementation("androidx.camera:camera-core:$cameraVersion")
     implementation("androidx.camera:camera-camera2:$cameraVersion")
     implementation("androidx.camera:camera-lifecycle:$cameraVersion")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         applicationId = "app.grapheneos.camera"
         minSdk = 29
         targetSdk = 32
-        versionCode = 43
+        versionCode = 44
         versionName = versionCode.toString()
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
     }
 
     compileSdk = 32
-    buildToolsVersion = "32.0.0"
+    buildToolsVersion = "33.0.0"
 
     defaultConfig {
         applicationId = "app.grapheneos.camera"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,10 @@ android {
     buildFeatures {
         viewBinding = true
     }
+
+    lintOptions {
+        disable("LintError")
+    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         }
     }
 
-    compileSdk = 32
+    compileSdk = 33
     buildToolsVersion = "33.0.0"
 
     defaultConfig {

--- a/app/src/main/java/app/grapheneos/camera/CapturedItems.kt
+++ b/app/src/main/java/app/grapheneos/camera/CapturedItems.kt
@@ -69,7 +69,7 @@ class CapturedItem(
             override fun createFromParcel(source: Parcel): CapturedItem {
                 val type = source.readByte().toInt()
                 val dateString = source.readString()!!
-                val uri = source.readParcelable<Uri>(null)!!
+                val uri = source.readParcelableCompat<Uri>(null)!!
                 return CapturedItem(type, dateString, uri)
             }
 

--- a/app/src/main/java/app/grapheneos/camera/ParcelCompat.kt
+++ b/app/src/main/java/app/grapheneos/camera/ParcelCompat.kt
@@ -1,0 +1,15 @@
+package app.grapheneos.camera
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+
+inline internal fun <reified T : Parcelable> Parcel.readParcelableCompat(loader: ClassLoader?): T? {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("DEPRECATION")
+        this.readParcelable<T>(loader)
+    } else {
+        this.readParcelable(loader, T::class.java)
+    }
+}

--- a/app/src/main/java/app/grapheneos/camera/ui/ZoomableImageView.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/ZoomableImageView.kt
@@ -172,7 +172,7 @@ class ZoomableImageView @JvmOverloads constructor(
             return true
         }
 
-        override fun onScaleEnd(detector: ScaleGestureDetector?) {
+        override fun onScaleEnd(detector: ScaleGestureDetector) {
             super.onScaleEnd(detector)
             if (saveScale == 1f) {
                 gActivity.gallerySlider.isUserInputEnabled = true

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
@@ -46,7 +46,7 @@ open class CaptureActivity : MainActivity() {
         confirmButton = findViewById(R.id.confirm_button)
 
         if (intent.extras?.containsKey(EXTRA_OUTPUT) == true) {
-            outputUri = intent.extras?.get(EXTRA_OUTPUT) as Uri
+            outputUri = intent.getParcelableExtraCompat<Uri>(EXTRA_OUTPUT) as Uri
         }
 
         // Disable capture button for a while (to avoid picture capture)

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
@@ -446,7 +446,7 @@ class InAppGallery : AppCompatActivity() {
         gallerySlider.setPageTransformer(GSlideTransformer())
 
         val showVideosOnly = intent.getBooleanExtra(INTENT_KEY_VIDEO_ONLY_MODE, false)
-        val listOfSecureModeCapturedItems = intent.getParcelableArrayListExtra<CapturedItem>(INTENT_KEY_LIST_OF_SECURE_MODE_CAPTURED_ITEMS)
+        val listOfSecureModeCapturedItems = intent.getParcelableArrayListExtraCompat<CapturedItem>(INTENT_KEY_LIST_OF_SECURE_MODE_CAPTURED_ITEMS)
 
         asyncLoaderOfCapturedItems.execute {
             val unprocessedItems: List<CapturedItem> = try {
@@ -479,7 +479,7 @@ class InAppGallery : AppCompatActivity() {
             mainExecutor.execute { asyncResultReady(items) }
         }
 
-        val lastCapturedItem = intent.getParcelableExtra<CapturedItem>(INTENT_KEY_LAST_CAPTURED_ITEM)
+        val lastCapturedItem = intent.getParcelableExtraCompat<CapturedItem>(INTENT_KEY_LAST_CAPTURED_ITEM)
 
         if (lastCapturedItem != null) {
             val list = ArrayList<CapturedItem>()

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/IntentCompat.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/IntentCompat.kt
@@ -1,0 +1,25 @@
+package app.grapheneos.camera.ui.activities
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+
+inline internal fun <reified T : Parcelable> Intent.getParcelableExtraCompat(name: String): T? {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("DEPRECATION")
+        this.getParcelableExtra<T>(name)
+    } else {
+        this.getParcelableExtra(name, T::class.java)
+    }
+}
+
+inline internal fun <reified T : Parcelable> Intent.getParcelableArrayListExtraCompat(name: String): ArrayList<T>? {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("DEPRECATION")
+        this.getParcelableArrayListExtra<T>(name)
+    } else {
+        this.getParcelableArrayListExtra(name, T::class.java)
+    }
+}

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -1306,21 +1306,21 @@ open class MainActivity : AppCompatActivity(),
         private const val SWIPE_VELOCITY_THRESHOLD = 100
     }
 
-    override fun onDown(p0: MotionEvent?): Boolean {
+    override fun onDown(p0: MotionEvent): Boolean {
         return false
     }
 
-    override fun onShowPress(p0: MotionEvent?) {}
+    override fun onShowPress(p0: MotionEvent) {}
 
-    override fun onSingleTapUp(p0: MotionEvent?): Boolean {
+    override fun onSingleTapUp(p0: MotionEvent): Boolean {
         return false
     }
 
-    override fun onScroll(p0: MotionEvent?, p1: MotionEvent?, p2: Float, p3: Float): Boolean {
+    override fun onScroll(p0: MotionEvent, p1: MotionEvent, p2: Float, p3: Float): Boolean {
         return false
     }
 
-    override fun onLongPress(p0: MotionEvent?) {}
+    override fun onLongPress(p0: MotionEvent) {}
 
     override fun onFling(
         e1: MotionEvent, e2: MotionEvent,
@@ -1410,15 +1410,15 @@ open class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onSingleTapConfirmed(p0: MotionEvent?): Boolean {
+    override fun onSingleTapConfirmed(p0: MotionEvent): Boolean {
         return false
     }
 
-    override fun onDoubleTap(p0: MotionEvent?): Boolean {
+    override fun onDoubleTap(p0: MotionEvent): Boolean {
         return false
     }
 
-    override fun onDoubleTapEvent(p0: MotionEvent?): Boolean {
+    override fun onDoubleTapEvent(p0: MotionEvent): Boolean {
         return false
     }
 

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/VideoPlayer.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/VideoPlayer.kt
@@ -31,7 +31,7 @@ class VideoPlayer : AppCompatActivity() {
             throw Exception("Video Player requires videoUri")
         }
 
-        val uri = intent.extras!!.get("videoUri") as Uri
+        val uri = intent.getParcelableExtraCompat<Uri>("videoUri") as Uri
 
         val videoView = binding.videoPlayer
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.3")
+        classpath("com.android.tools.build:gradle:7.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.1.3")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
     }
 }
 


### PR DESCRIPTION
`Linkify.ALL` alternative, `TextClassifier.generateLinks` is currently being looked if safe to call, replace the current implementation at https://github.com/repository-staging/Camera/blob/61506b061089e1ca1a19c4ed129054a9d81d59bf/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt#L1103-L1104