### PR TITLE
[UNTESTED] layout improvements

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/CountDownTimerUI.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/CountDownTimerUI.kt
@@ -6,10 +6,8 @@ import android.os.CountDownTimer
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.camera.core.AspectRatio
 import app.grapheneos.camera.CamConfig
 import app.grapheneos.camera.ui.activities.CaptureActivity
 import app.grapheneos.camera.ui.activities.MainActivity
@@ -96,14 +94,6 @@ class CountDownTimerUI @JvmOverloads constructor(
     }
 
     private fun beforeTimeStarts() {
-
-        val params: ViewGroup.LayoutParams = layoutParams
-        params.height = if (camConfig.aspectRatio == AspectRatio.RATIO_4_3) {
-            mActivity.previewView.width * 4 / 3
-        } else {
-            mActivity.previewView.height
-        }
-        layoutParams = params
 
         mActivity.settingsIcon.visibility = View.INVISIBLE
         mActivity.thirdOption.visibility = View.INVISIBLE

--- a/app/src/main/java/app/grapheneos/camera/ui/CustomGrid.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/CustomGrid.kt
@@ -39,22 +39,16 @@ class CustomGrid @JvmOverloads constructor(
             return
         }
 
-        val previewHeight = if (camConfig.aspectRatio == AspectRatio.RATIO_16_9) {
-            mActivity.previewView.width * 16 / 9
-        } else {
-            mActivity.previewView.width * 4 / 3
-        }
-
         if (camConfig.gridType == CamConfig.GridType.GOLDEN_RATIO) {
 
             val cx = width / 2f
-            val cy = previewHeight / 2f
+            val cy = height / 2f
 
             val dxH = width / 8f
-            val dyH = previewHeight / 8f
+            val dyH = height / 8f
 
-            canvas.drawLine(cx - dxH, 0f, cx - dxH, previewHeight.toFloat(), paint)
-            canvas.drawLine(cx + dxH, 0f, cx + dxH, previewHeight.toFloat(), paint)
+            canvas.drawLine(cx - dxH, 0f, cx - dxH, height.toFloat(), paint)
+            canvas.drawLine(cx + dxH, 0f, cx + dxH, height.toFloat(), paint)
             canvas.drawLine(0f, cy - dyH, width.toFloat(), cy - dyH, paint)
             canvas.drawLine(0f, cy + dyH, width.toFloat(), cy + dyH, paint)
 
@@ -70,27 +64,27 @@ class CustomGrid @JvmOverloads constructor(
                 width / seed * 2f,
                 0f,
                 width / seed * 2f,
-                previewHeight.toFloat(),
+                height.toFloat(),
                 paint
             )
-            canvas.drawLine(width / seed, 0f, width / seed, previewHeight.toFloat(), paint)
+            canvas.drawLine(width / seed, 0f, width / seed, height.toFloat(), paint)
             canvas.drawLine(
-                0f, previewHeight / seed * 2f,
-                width.toFloat(), previewHeight / seed * 2f, paint
+                0f, height / seed * 2f,
+                width.toFloat(), height / seed * 2f, paint
             )
-            canvas.drawLine(0f, previewHeight / seed, width.toFloat(), previewHeight / seed, paint)
+            canvas.drawLine(0f, height / seed, width.toFloat(), height / seed, paint)
 
             if (seed == 4f) {
                 canvas.drawLine(
                     width / seed * 3f,
                     0f,
                     width / seed * 3f,
-                    previewHeight.toFloat(),
+                    height.toFloat(),
                     paint
                 )
                 canvas.drawLine(
-                    0f, previewHeight / seed * 3f,
-                    width.toFloat(), previewHeight / seed * 3f, paint
+                    0f, height / seed * 3f,
+                    width.toFloat(), height / seed * 3f, paint
                 )
             }
         }

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -130,7 +130,6 @@ open class MainActivity : AppCompatActivity(),
     private var audioPermissionDialog: AlertDialog? = null
     private var lastFrame: Bitmap? = null
 
-    private lateinit var mainFrame: View
     lateinit var rootView: View
 
     lateinit var qrScanToggles: View
@@ -857,8 +856,6 @@ open class MainActivity : AppCompatActivity(),
 
         rootView = binding.root
 
-        mainFrame = binding.mainFrame
-
         qrScanToggles = binding.qrScanToggles
 
         var isInsetSet = false
@@ -878,17 +875,9 @@ open class MainActivity : AppCompatActivity(),
             }
 
             if (insets.top != 0 && !isInsetSet) {
-                mainFrame.layoutParams =
-                    (mainFrame.layoutParams as ViewGroup.MarginLayoutParams).let {
-                        it.setMargins(
-                            it.leftMargin,
-                            (8 * resources.displayMetrics.density.toInt()) + insets.top,
-                            it.rightMargin,
-                            it.bottomMargin,
-                        )
-
-                        it
-                    }
+                previewContainer.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    updateMargins(top = (8 * resources.displayMetrics.density.toInt()) + insets.top)
+                }
 
                 qrScanToggles.layoutParams =
                     (qrScanToggles.layoutParams as ViewGroup.MarginLayoutParams).let {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -133,14 +133,18 @@
 
             <app.grapheneos.camera.ui.CountDownTimerUI
                 android:id="@+id/c_timer"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
                 android:visibility="gone"
                 android:shadowColor="#000000"
                 android:shadowDx="1.5"
                 android:shadowDy="1.3"
                 android:shadowRadius="1.6"
-                android:textColor="@color/white"/>
+                android:textColor="@color/white"
+                app:layout_constraintTop_toTopOf="@id/preview"
+                app:layout_constraintStart_toStartOf="@id/preview"
+                app:layout_constraintEnd_toEndOf="@id/preview"
+                app:layout_constraintBottom_toBottomOf="@id/preview"/>
 
             <app.grapheneos.camera.ui.CustomGrid
                 android:id="@+id/preview_grid"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -63,103 +63,103 @@
                     app:layout_constraintTop_toBottomOf="@id/preview"
                     app:layout_constraintBottom_toBottomOf="parent"/>
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <FrameLayout
-                android:id="@+id/g_circle_frame"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center">
-
-                <LinearLayout
-                    android:id="@+id/g_circle"
+                <FrameLayout
+                    android:id="@+id/g_circle_frame"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:rotation="0"
-                    android:paddingBottom="14sp"
-                    android:layout_marginBottom="9dp"
-                    android:orientation="vertical">
+                    android:layout_gravity="center">
 
-                    <TextView
-                        android:id="@+id/g_circle_text"
+                    <LinearLayout
+                        android:id="@+id/g_circle"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textSize="14sp"
-                        android:layout_marginBottom="4dp"
-                        android:shadowColor="#000000"
-                        android:shadowDx="1.5"
-                        android:shadowDy="1.3"
-                        android:shadowRadius="1.6"
-                        android:textColor="@color/white"
-                        android:textAlignment="center"/>
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:rotation="0"
+                        android:paddingBottom="14sp"
+                        android:layout_marginBottom="9dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/g_circle_text"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textSize="14sp"
+                            android:layout_marginBottom="4dp"
+                            android:shadowColor="#000000"
+                            android:shadowDx="1.5"
+                            android:shadowDy="1.3"
+                            android:shadowRadius="1.6"
+                            android:textColor="@color/white"
+                            android:textAlignment="center"/>
+
+                        <View
+                            android:id="@+id/g_circle_line_x"
+                            android:background="@drawable/white_shadow_rect"
+                            android:layout_width="120dp"
+                            android:layout_gravity="center"
+                            android:layout_height="2dp"/>
+
+                    </LinearLayout>
 
                     <View
-                        android:id="@+id/g_circle_line_x"
-                        android:background="@drawable/white_shadow_rect"
-                        android:layout_width="120dp"
+                        android:id="@+id/g_circle_line_z"
+                        android:background="@drawable/yellow_shadow_rect"
+                        android:layout_width="100dp"
                         android:layout_gravity="center"
-                        android:layout_height="2dp"/>
+                        android:layout_height="1.5dp"/>
 
-                </LinearLayout>
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:clipToPadding="false"
+                        android:orientation="horizontal">
 
-                <View
-                    android:id="@+id/g_circle_line_z"
-                    android:background="@drawable/yellow_shadow_rect"
-                    android:layout_width="100dp"
-                    android:layout_gravity="center"
-                    android:layout_height="1.5dp"/>
+                        <View
+                            android:id="@+id/g_circle_left_dash"
+                            android:background="@drawable/white_shadow_rect"
+                            android:layout_width="8dp"
+                            android:layout_height="2dp"/>
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:clipToPadding="false"
-                    android:orientation="horizontal">
+                        <View
+                            android:background="@android:color/transparent"
+                            android:layout_width="120dp"
+                            android:layout_height="1dp"/>
 
-                    <View
-                        android:id="@+id/g_circle_left_dash"
-                        android:background="@drawable/white_shadow_rect"
-                        android:layout_width="8dp"
-                        android:layout_height="2dp"/>
+                        <View
+                            android:id="@+id/g_circle_right_dash"
+                            android:layout_width="8dp"
+                            android:layout_height="2dp"
+                            android:background="@drawable/white_shadow_rect"/>
 
-                    <View
-                        android:background="@android:color/transparent"
-                        android:layout_width="120dp"
-                        android:layout_height="1dp"/>
+                    </LinearLayout>
 
-                    <View
-                        android:id="@+id/g_circle_right_dash"
-                        android:layout_width="8dp"
-                        android:layout_height="2dp"
-                        android:background="@drawable/white_shadow_rect"/>
+                </FrameLayout>
 
-                </LinearLayout>
+                <app.grapheneos.camera.ui.CountDownTimerUI
+                    android:id="@+id/c_timer"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone"
+                    android:shadowColor="#000000"
+                    android:shadowDx="1.5"
+                    android:shadowDy="1.3"
+                    android:shadowRadius="1.6"
+                    android:textColor="@color/white"/>
 
-            </FrameLayout>
+                <app.grapheneos.camera.ui.CustomGrid
+                    android:id="@+id/preview_grid"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"/>
 
-            <app.grapheneos.camera.ui.CountDownTimerUI
-                android:id="@+id/c_timer"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:visibility="gone"
-                android:shadowColor="#000000"
-                android:shadowDx="1.5"
-                android:shadowDy="1.3"
-                android:shadowRadius="1.6"
-                android:textColor="@color/white"/>
+                <ImageView
+                    android:id="@+id/main_overlay"
+                    android:scaleType="fitStart"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/loading_camera"/>
 
-            <app.grapheneos.camera.ui.CustomGrid
-                android:id="@+id/preview_grid"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
-
-            <ImageView
-                android:id="@+id/main_overlay"
-                android:scaleType="fitStart"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:contentDescription="@string/loading_camera"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -151,8 +151,12 @@
 
             <app.grapheneos.camera.ui.CustomGrid
                 android:id="@+id/preview_grid"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="@id/preview"
+                app:layout_constraintStart_toStartOf="@id/preview"
+                app:layout_constraintEnd_toEndOf="@id/preview"
+                app:layout_constraintBottom_toBottomOf="@id/preview"/>
 
             <ImageView
                 android:id="@+id/main_overlay"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,154 +14,147 @@
         android:background="@color/default_bg"
         tools:context=".ui.activities.MainActivity">
 
-        <FrameLayout
-            android:id="@+id/main_frame"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/preview_container"
             android:layout_height="match_parent"
             android:layout_width="match_parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/preview_container"
+            <androidx.camera.view.PreviewView
+                android:id="@+id/preview"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintDimensionRatio="H,9:16"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <app.grapheneos.camera.ui.QROverlay
+                android:id="@+id/qr_overlay"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:visibility="invisible"
+                app:layout_constraintTop_toTopOf="@id/preview"
+                app:layout_constraintStart_toStartOf="@id/preview"
+                app:layout_constraintEnd_toEndOf="@id/preview"
+                app:layout_constraintBottom_toBottomOf="@id/preview"
+                android:layerType="software"/>
+
+            <ImageView
+                android:layout_width="84dp"
+                android:layout_height="84dp"
+                android:id="@+id/focusRing"
+                android:src="@drawable/focus_ring"
+                android:visibility="invisible"
+                android:contentDescription="@string/focus_ring"
+                app:layout_constraintTop_toTopOf="@id/preview"
+                app:layout_constraintStart_toStartOf="@id/preview"/>
+
+            <!-- Hides part of focus ring that is outside of the preview by occupying the area below the preview. -->
+            <View
+                android:id="@+id/bottom_overlay"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="@color/default_bg"
+                app:layout_constraintTop_toBottomOf="@id/preview"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+            <FrameLayout
+                android:id="@+id/g_circle_frame"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_width="match_parent">
+                android:layout_gravity="center">
 
-                <androidx.camera.view.PreviewView
-                    android:id="@+id/preview"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    app:layout_constraintDimensionRatio="H,9:16"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <app.grapheneos.camera.ui.QROverlay
-                    android:id="@+id/qr_overlay"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:visibility="invisible"
-                    app:layout_constraintTop_toTopOf="@id/preview"
-                    app:layout_constraintStart_toStartOf="@id/preview"
-                    app:layout_constraintEnd_toEndOf="@id/preview"
-                    app:layout_constraintBottom_toBottomOf="@id/preview"
-                    android:layerType="software"/>
-
-                <ImageView
-                    android:layout_width="84dp"
-                    android:layout_height="84dp"
-                    android:id="@+id/focusRing"
-                    android:src="@drawable/focus_ring"
-                    android:visibility="invisible"
-                    android:contentDescription="@string/focus_ring"
-                    app:layout_constraintTop_toTopOf="@id/preview"
-                    app:layout_constraintStart_toStartOf="@id/preview"/>
-
-                <!-- Hides part of focus ring that is outside of the preview by occupying the area below the preview. -->
-                <View
-                    android:id="@+id/bottom_overlay"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:background="@color/default_bg"
-                    app:layout_constraintTop_toBottomOf="@id/preview"
-                    app:layout_constraintBottom_toBottomOf="parent"/>
-
-                <FrameLayout
-                    android:id="@+id/g_circle_frame"
+                <LinearLayout
+                    android:id="@+id/g_circle"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_gravity="center">
+                    android:gravity="center"
+                    android:rotation="0"
+                    android:paddingBottom="14sp"
+                    android:layout_marginBottom="9dp"
+                    android:orientation="vertical">
 
-                    <LinearLayout
-                        android:id="@+id/g_circle"
+                    <TextView
+                        android:id="@+id/g_circle_text"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:gravity="center"
-                        android:rotation="0"
-                        android:paddingBottom="14sp"
-                        android:layout_marginBottom="9dp"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/g_circle_text"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textSize="14sp"
-                            android:layout_marginBottom="4dp"
-                            android:shadowColor="#000000"
-                            android:shadowDx="1.5"
-                            android:shadowDy="1.3"
-                            android:shadowRadius="1.6"
-                            android:textColor="@color/white"
-                            android:textAlignment="center"/>
-
-                        <View
-                            android:id="@+id/g_circle_line_x"
-                            android:background="@drawable/white_shadow_rect"
-                            android:layout_width="120dp"
-                            android:layout_gravity="center"
-                            android:layout_height="2dp"/>
-
-                    </LinearLayout>
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:layout_marginBottom="4dp"
+                        android:shadowColor="#000000"
+                        android:shadowDx="1.5"
+                        android:shadowDy="1.3"
+                        android:shadowRadius="1.6"
+                        android:textColor="@color/white"
+                        android:textAlignment="center"/>
 
                     <View
-                        android:id="@+id/g_circle_line_z"
-                        android:background="@drawable/yellow_shadow_rect"
-                        android:layout_width="100dp"
+                        android:id="@+id/g_circle_line_x"
+                        android:background="@drawable/white_shadow_rect"
+                        android:layout_width="120dp"
                         android:layout_gravity="center"
-                        android:layout_height="1.5dp"/>
+                        android:layout_height="2dp"/>
 
-                    <LinearLayout
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:clipToPadding="false"
-                        android:orientation="horizontal">
+                </LinearLayout>
 
-                        <View
-                            android:id="@+id/g_circle_left_dash"
-                            android:background="@drawable/white_shadow_rect"
-                            android:layout_width="8dp"
-                            android:layout_height="2dp"/>
+                <View
+                    android:id="@+id/g_circle_line_z"
+                    android:background="@drawable/yellow_shadow_rect"
+                    android:layout_width="100dp"
+                    android:layout_gravity="center"
+                    android:layout_height="1.5dp"/>
 
-                        <View
-                            android:background="@android:color/transparent"
-                            android:layout_width="120dp"
-                            android:layout_height="1dp"/>
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:clipToPadding="false"
+                    android:orientation="horizontal">
 
-                        <View
-                            android:id="@+id/g_circle_right_dash"
-                            android:layout_width="8dp"
-                            android:layout_height="2dp"
-                            android:background="@drawable/white_shadow_rect"/>
+                    <View
+                        android:id="@+id/g_circle_left_dash"
+                        android:background="@drawable/white_shadow_rect"
+                        android:layout_width="8dp"
+                        android:layout_height="2dp"/>
 
-                    </LinearLayout>
+                    <View
+                        android:background="@android:color/transparent"
+                        android:layout_width="120dp"
+                        android:layout_height="1dp"/>
 
-                </FrameLayout>
+                    <View
+                        android:id="@+id/g_circle_right_dash"
+                        android:layout_width="8dp"
+                        android:layout_height="2dp"
+                        android:background="@drawable/white_shadow_rect"/>
 
-                <app.grapheneos.camera.ui.CountDownTimerUI
-                    android:id="@+id/c_timer"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:visibility="gone"
-                    android:shadowColor="#000000"
-                    android:shadowDx="1.5"
-                    android:shadowDy="1.3"
-                    android:shadowRadius="1.6"
-                    android:textColor="@color/white"/>
+                </LinearLayout>
 
-                <app.grapheneos.camera.ui.CustomGrid
-                    android:id="@+id/preview_grid"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"/>
+            </FrameLayout>
 
-                <ImageView
-                    android:id="@+id/main_overlay"
-                    android:scaleType="fitStart"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:contentDescription="@string/loading_camera"/>
+            <app.grapheneos.camera.ui.CountDownTimerUI
+                android:id="@+id/c_timer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                android:shadowColor="#000000"
+                android:shadowDx="1.5"
+                android:shadowDy="1.3"
+                android:shadowRadius="1.6"
+                android:textColor="@color/white"/>
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            <app.grapheneos.camera.ui.CustomGrid
+                android:id="@+id/preview_grid"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
 
-        </FrameLayout>
+            <ImageView
+                android:id="@+id/main_overlay"
+                android:scaleType="fitStart"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/loading_camera"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout
             android:id="@+id/three_buttons"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -52,10 +52,12 @@
             <!-- Hides part of focus ring that is outside of the preview by occupying the area below the preview. -->
             <View
                 android:id="@+id/bottom_overlay"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:background="@color/default_bg"
                 app:layout_constraintTop_toBottomOf="@id/preview"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
             <FrameLayout
@@ -161,9 +163,13 @@
             <ImageView
                 android:id="@+id/main_overlay"
                 android:scaleType="fitStart"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:contentDescription="@string/loading_camera"/>
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:contentDescription="@string/loading_camera"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,9 +60,12 @@
 
             <FrameLayout
                 android:id="@+id/g_circle_frame"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center">
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toTopOf="@id/preview"
+                app:layout_constraintStart_toStartOf="@id/preview"
+                app:layout_constraintEnd_toEndOf="@id/preview"
+                app:layout_constraintBottom_toBottomOf="@id/preview">
 
                 <LinearLayout
                     android:id="@+id/g_circle"


### PR DESCRIPTION
This is part of effort to migrate `main_activity.xml` to contraint layout #82. It includes the following changes:

- remove `main_frame` and replace it with `preview_container`
- do not explicitly set `c_timer` (countdown timer) height and let constraints take care of that
- center gyroscope suggestions to the preview
- use preview grid's height instead of preview's height to calculate the area on which to draw the preview grid, since preview
 grid's height is the same as preview's height
- use `match_contraint` instead of `match_parent` in `preview_container` as `match_parent` is not recommended practice for constraint layouts