### PR TITLE
Do not automatically launch editor when "Open with" menu is selected

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
@@ -216,7 +216,12 @@ class InAppGallery : AppCompatActivity() {
                 showMessage(getString(R.string.no_editor_app_error))
             }
         } else {
-            editIntentLauncher.launch(Intent.createChooser(editIntent, getString(R.string.edit_image)))
+            editIntentLauncher.launch(
+                Intent.createChooser(
+                     editIntent,
+                     getString(R.string.edit_image)
+                ).putExtra(Intent.EXTRA_AUTO_LAUNCH_SINGLE_CHOICE, false)
+            )
         }
     }
 


### PR DESCRIPTION
When there's only one photo editor available, it automatically launch the editor. Allow users to confirm instead compared to Edit menu