### PR TITLE
bugfixes: fix app crashes when launching Qr Scanner from QuickTile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -190,6 +190,7 @@
         <activity
             android:name=".ui.activities.QrTile"
             android:exported="true"
+            android:screenOrientation="nosensor"
             android:excludeFromRecents="true"/>
 
     </application>


### PR DESCRIPTION
fixes #352  