### PR TITLE
unregister `autoRotateSettingObserver` to avoid memory leak

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ktx/SystemSettingsObserver.kt
+++ b/app/src/main/java/app/grapheneos/camera/ktx/SystemSettingsObserver.kt
@@ -1,0 +1,42 @@
+package app.grapheneos.camera.ktx
+
+import android.content.Context
+import android.database.ContentObserver
+import android.os.Handler
+import android.provider.Settings
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+
+class SystemSettingsObserver(
+    lifecycle: Lifecycle,
+    private val key: String,
+    private val context: Context,
+    private val notifyForDescendants: Boolean = true,
+    private val callback: () -> Unit
+) : DefaultLifecycleObserver, ContentObserver(Handler(context.mainLooper)) {
+
+    private val contentResolver by lazy { context.applicationContext.contentResolver }
+
+    init {
+        lifecycle.addObserver(this)
+    }
+
+    override fun onChange(selfChange: Boolean) {
+        super.onChange(selfChange)
+        callback.invoke()
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(key), notifyForDescendants, this
+        )
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        contentResolver.unregisterContentObserver(this)
+    }
+
+}

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -80,6 +80,7 @@ import app.grapheneos.camera.capturer.getVideoThumbnail
 import app.grapheneos.camera.capturer.isTakingPicture
 import app.grapheneos.camera.databinding.ActivityMainBinding
 import app.grapheneos.camera.databinding.ScanResultDialogBinding
+import app.grapheneos.camera.ktx.SystemSettingsObserver
 import app.grapheneos.camera.notifier.SensorOrientationChangeNotifier
 import app.grapheneos.camera.ui.BottomTabLayout
 import app.grapheneos.camera.ui.CountDownTimerUI
@@ -224,13 +225,6 @@ open class MainActivity : AppCompatActivity(),
     private val handler = Handler(Looper.getMainLooper())
 
     private lateinit var snackBar: Snackbar
-
-    private val autoRotateSettingObserver =
-        object : ContentObserver(Handler(Looper.myLooper()!!)) {
-            override fun onChange(selfChange: Boolean) {
-                forceUpdateOrientationSensor()
-            }
-        }
 
     private lateinit var focusRing: ImageView
 
@@ -927,11 +921,9 @@ open class MainActivity : AppCompatActivity(),
 
         settingsDialog = SettingsDialog(this)
 
-        contentResolver.registerContentObserver(
-            Settings.System.getUriFor(Settings.System.ACCELEROMETER_ROTATION),
-            true,
-            autoRotateSettingObserver
-        )
+        SystemSettingsObserver(lifecycle,Settings.System.ACCELEROMETER_ROTATION,this) {
+            forceUpdateOrientationSensor()
+        }
 
         focusRing = binding.focusRing
 


### PR DESCRIPTION
fixes #365 