### PR TITLE
Add 60 fps toggle to Camera app

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -286,6 +286,7 @@ class VideoCapturer(private val mActivity: MainActivity) {
         mActivity.settingsDialog.includeAudioToggle.isEnabled = false
         mActivity.settingsDialog.videoQualitySpinner.isEnabled = false
         mActivity.settingsDialog.enableEISToggle.isEnabled = false
+        mActivity.settingsDialog.enable60fpsToggle.isEnabled = false
 
         mActivity.flipCamIcon.setImageResource(R.drawable.pause)
         isPaused = false
@@ -324,6 +325,7 @@ class VideoCapturer(private val mActivity: MainActivity) {
         mActivity.settingsDialog.includeAudioToggle.isEnabled = true
         mActivity.settingsDialog.videoQualitySpinner.isEnabled = true
         mActivity.settingsDialog.enableEISToggle.isEnabled = true
+        mActivity.settingsDialog.enable60fpsToggle.isEnabled = true
 
         if (mActivity !is VideoCaptureActivity) {
             mActivity.thirdOption.visibility = View.VISIBLE

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -66,6 +66,7 @@ class SettingsDialog(val mActivity: MainActivity) :
 
     var includeAudioToggle: SwitchCompat
     var enableEISToggle: SwitchCompat
+    var enable60fpsToggle: SwitchCompat
 
     var selfIlluminationToggle: SwitchCompat
 
@@ -73,6 +74,7 @@ class SettingsDialog(val mActivity: MainActivity) :
 
     private var includeAudioSetting: View
     private var enableEISSetting: View
+    private var enable60fpsSetting: View
     private var selfIlluminationSetting: View
     private var videoQualitySetting: View
     private var timerSetting: View
@@ -316,6 +318,7 @@ class SettingsDialog(val mActivity: MainActivity) :
 
         includeAudioSetting = binding.includeAudioSetting
         enableEISSetting = binding.enableEisSetting
+        enable60fpsSetting = binding.enable60fpsSetting
         selfIlluminationSetting = binding.selfIlluminationSetting
         videoQualitySetting = binding.videoQualitySetting
         timerSetting = binding.timerSetting
@@ -333,6 +336,14 @@ class SettingsDialog(val mActivity: MainActivity) :
             camConfig.enableEIS = enableEISToggle.isChecked
         }
         enableEISToggle.setOnCheckedChangeListener { _, _ ->
+            camConfig.startCamera(true)
+        }
+
+        enable60fpsToggle = binding.enable60fpsSwitch
+        enable60fpsToggle.setOnClickListener {
+            camConfig.enable60fps = enable60fpsToggle.isChecked
+        }
+        enable60fpsToggle.setOnCheckedChangeListener { _, _ ->
             camConfig.startCamera(true)
         }
 
@@ -375,10 +386,12 @@ class SettingsDialog(val mActivity: MainActivity) :
                         if (mode == CameraMetadata.CONTROL_VIDEO_STABILIZATION_MODE_ON)
                             enableEISSetting.visibility = View.VISIBLE
             }
+            enable60fpsSetting.visibility = View.VISIBLE
             videoQualitySetting.visibility = View.VISIBLE
         } else {
             includeAudioSetting.visibility = View.GONE
             enableEISSetting.visibility = View.GONE
+            enable60fpsSetting.visibility = View.GONE
             videoQualitySetting.visibility = View.GONE
         }
 

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -250,6 +250,29 @@
 
                     </LinearLayout>
 
+                    <LinearLayout
+                        android:id="@+id/enable_60fps_setting"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal"
+                        android:paddingHorizontal="@dimen/settings_dialog_menu_item_horizontal"
+                        android:paddingVertical="@dimen/settings_dialog_menu_item_vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:text="@string/enable_60fps" />
+
+                        <androidx.appcompat.widget.SwitchCompat
+                            android:id="@+id/enable_60fps_switch"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="end"
+                            android:checked="false" />
+
+                    </LinearLayout>
+
                     <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="grid_toggle">Grid Toggle</string>
     <string name="include_audio">Include Audio</string>
     <string name="enable_eis">Enable EIS</string>
+    <string name="enable_60fps">Enable 60 FPS</string>
     <string name="video_quality">Video Quality</string>
     <string name="optimize_for">Optimize for</string>
     <string name="quality">Quality</string>


### PR DESCRIPTION
Hi! If interested, I've gone and added a "60fps" toggle to the camera app. I'm submitting this PR to see if there's interest in this feature, or something _like_ it. The purpose is to enable higher frame rate video capture than the current default. Let me know your thoughts!

This change specifically adds a toggle to the Camera app allowing the user to record video at a higher
frame rate ( 60fps ). The default is unchanged, and this setting is _disabled_  by default.

It's possible that users might want a bit more flexibility, so they could set the frame rate in the "other settings" page, rather than in the inline menu, but I felt this was acceptable as a first attempt.

Related to https://github.com/GrapheneOS/Camera/issues/51

Screenshot:

![screenshot](https://github.com/GrapheneOS/Camera/assets/139090555/41081c82-92a1-4594-80d6-c8d682b4becf)