### PR TITLE
Use blendMode over xfermode

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/QROverlay.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/QROverlay.kt
@@ -2,11 +2,10 @@ package app.grapheneos.camera.ui
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.BlendMode
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
 import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
@@ -28,7 +27,7 @@ class QROverlay(context: Context, attrs: AttributeSet) : View(context, attrs) {
 
     private val eraserPaint: Paint = Paint().apply {
         strokeWidth = boxPaint.strokeWidth
-        xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+        blendMode = BlendMode.CLEAR
     }
 
     private val boxCornerRadius: Float =


### PR DESCRIPTION
This PR aims to support QR for devices with hardware acceleration enabled

(Needs testing on a device where the issue #373 is currently being faced on the main branch)