### PR TITLE
Disable including audio in-recording when it starts disabled

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -38,6 +38,7 @@ import java.util.Date
 import java.util.Locale
 
 class VideoCapturer(private val mActivity: MainActivity) {
+
     val camConfig = mActivity.camConfig
 
     var isRecording = false
@@ -46,6 +47,8 @@ class VideoCapturer(private val mActivity: MainActivity) {
     private val videoFileFormat = ".mp4"
 
     private var recording: Recording? = null
+
+    var includeAudio: Boolean = false
 
     var isPaused = false
         set(value) {
@@ -166,7 +169,7 @@ class VideoCapturer(private val mActivity: MainActivity) {
         val dateString = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
         val fileName = VIDEO_NAME_PREFIX + dateString + videoFileFormat
 
-        var includeAudio = false
+        includeAudio = false
 
         val ctx = mActivity
 

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -336,6 +336,12 @@ class SettingsDialog(val mActivity: MainActivity) :
                     return@setOnClickListener
                 }
 
+                if (!mActivity.videoCapturer.includeAudio) {
+                    mActivity.showMessage("Enabling audio while recording is not currently supported when it was disabled at the start")
+                    includeAudioToggle.isChecked = false
+                    return@setOnClickListener
+                }
+
                 if  (includeAudioToggle.isChecked) {
                     mActivity.videoCapturer.unmuteRecording()
                 } else {


### PR DESCRIPTION
Temporary workaround until we have a reliable way to start recording with mic mute while allowing the user to unmute the mic later