### PR TITLE
Prevent specifying preview stabilization option for unsupported devices

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -441,7 +441,7 @@ class CamConfig(private val mActivity: MainActivity) {
 
     var enableEIS: Boolean
         get() {
-            return isStabilizationSupported() && mActivity.settingsDialog.enableEISToggle.isChecked
+            return isVideoStabilizationSupported() && mActivity.settingsDialog.enableEISToggle.isChecked
         }
         set(value) {
             val editor = commonPref.edit()
@@ -557,7 +557,16 @@ class CamConfig(private val mActivity: MainActivity) {
         camera!!.cameraInfo.isZslSupported
     }
 
-    fun isStabilizationSupported() : Boolean {
+    fun isVideoStabilizationSupported() : Boolean {
+        return isRecorderStabilizationSupported()
+    }
+
+    private fun isPreviewStabilizationSupported() : Boolean {
+        return Preview.getPreviewCapabilities(getCurrentCameraInfo()).isStabilizationSupported
+    }
+
+
+    private fun isRecorderStabilizationSupported() : Boolean {
         return Recorder.getVideoCapabilities(getCurrentCameraInfo()).isStabilizationSupported
     }
 
@@ -1196,7 +1205,7 @@ class CamConfig(private val mActivity: MainActivity) {
                 ResolutionSelector.Builder().setAspectRatioStrategy(aspectRatioStrategy).build()
             )
 
-        if (isVideoMode) {
+        if (isVideoMode && isPreviewStabilizationSupported()) {
             previewBuilder.setPreviewStabilizationEnabled(enableEIS)
         }
 

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -400,7 +400,7 @@ class SettingsDialog(val mActivity: MainActivity) :
             includeAudioSetting.visibility = View.VISIBLE
             enableEISSetting.visibility = View.GONE
             videoQualitySetting.visibility = View.VISIBLE
-            enableEISSetting.visibility = if (camConfig.isStabilizationSupported()) {
+            enableEISSetting.visibility = if (camConfig.isVideoStabilizationSupported()) {
                 View.VISIBLE
             } else {
                 View.GONE


### PR DESCRIPTION
Helps resolve the issue specified at #457

Video stabilization has two modes, ON and PREVIEW_STABILIZATION, rather than preview and video recorder stabilization being two independent options. PREVIEW_STABILIZATION, the relatively newer option across devices gets chosen when preview stabilization is enabled on the Preview, but this may not be available on all devices,

This PR would ensure that PREVIEW_STABILIZATION is opted for only when its available, and otherwise the default ON mode on devices that support video stabilization in general