### PR TITLE
Fix crash due to assertion in mute/unmute recording method

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -365,13 +365,15 @@ class VideoCapturer(private val mActivity: MainActivity) {
     }
 
     fun muteRecording() {
-        check(isRecording && camConfig.includeAudio)
+        if (!isRecording) return
+        check(camConfig.includeAudio)
         isMuted = true
         recording?.mute(true)
     }
 
     fun unmuteRecording() {
-        check(isRecording && camConfig.includeAudio)
+        if (!isRecording) return
+        check(camConfig.includeAudio)
         isMuted = false
         recording?.mute(false)
     }


### PR DESCRIPTION
This can be reproduced by repeatedly pressing the mute toggle as soon as the stop recording button is pressed.

The UI is being hidden in the right order in the code, but the click event could be handled after the recording stops.

The changes in this PR replace the relevant part of the assertion with an if statement that skips muting/unmuting the audio in cases when the recording has already stopped.