### PR TITLE
Add support for persistent exposure setting

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -105,6 +105,10 @@ class CamConfig(private val mActivity: MainActivity) {
 
             const val REMOVE_EXIF_AFTER_CAPTURE = "remove_exif_after_capture"
 
+            const val PERSIST_EXPOSURE_LEVEL = "persist_exposure_level"
+
+            const val EXPOSURE_LEVEL = "exposure_level"
+
             const val GYROSCOPE_SUGGESTIONS = "gyroscope_suggestions"
 
             const val CAMERA_SOUNDS = "camera_sounds"
@@ -149,6 +153,10 @@ class CamConfig(private val mActivity: MainActivity) {
             const val PHOTO_QUALITY = 0
 
             const val REMOVE_EXIF_AFTER_CAPTURE = true
+
+            const val PERSIST_EXPOSURE_LEVEL = false
+
+            const val EXPOSURE_LEVEL = 0
 
             const val GYROSCOPE_SUGGESTIONS = false
 
@@ -534,6 +542,50 @@ class CamConfig(private val mActivity: MainActivity) {
             val editor = commonPref.edit()
             editor.putBoolean(
                 SettingValues.Key.REMOVE_EXIF_AFTER_CAPTURE,
+                value
+            )
+            editor.apply()
+        }
+
+    var persistExposureLevel: Boolean
+        get() {
+            return commonPref.getBoolean(
+                SettingValues.Key.PERSIST_EXPOSURE_LEVEL,
+                SettingValues.Default.PERSIST_EXPOSURE_LEVEL
+            )
+        }
+        set(value) {
+            val editor = commonPref.edit()
+            editor.putBoolean(
+                SettingValues.Key.PERSIST_EXPOSURE_LEVEL,
+                value
+            )
+            editor.apply()
+        }
+
+    private val exposureLevelKey: String
+        get() {
+
+            val pf = if (lensFacing == CameraSelector.LENS_FACING_FRONT) {
+                "FRONT"
+            } else {
+                "BACK"
+            }
+
+            return "${SettingValues.Key.EXPOSURE_LEVEL}_$pf"
+        }
+
+    var exposureLevel: Int
+        get() {
+            return modePref.getInt(
+                exposureLevelKey,
+                SettingValues.Default.EXPOSURE_LEVEL,
+            )
+        }
+        set(value) {
+            val editor = modePref.edit()
+            editor.putInt(
+                exposureLevelKey,
                 value
             )
             editor.apply()
@@ -1261,6 +1313,10 @@ class CamConfig(private val mActivity: MainActivity) {
         }
 
         mActivity.zoomBar.updateThumb(false)
+
+        if (persistExposureLevel) {
+            camera?.cameraControl?.setExposureCompensationIndex(exposureLevel)
+        }
 
         camera?.cameraInfo?.exposureState?.let { mActivity.exposureBar.setExposureConfig(it) }
 

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
@@ -236,6 +236,14 @@ open class MoreSettings : AppCompatActivity(), TextView.OnEditorActionListener {
             }
         }
 
+        val persistExposureToggle = binding.persistExposureLevelToggle
+
+        persistExposureToggle.isChecked = camConfig.persistExposureLevel
+
+        persistExposureToggle.setOnClickListener {
+            camConfig.persistExposureLevel = persistExposureToggle.isChecked
+        }
+
         if (!showStorageSettings) {
             binding.storageLocationSettings.visibility = View.GONE
         }

--- a/app/src/main/java/app/grapheneos/camera/ui/seekbar/ExposureBar.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/seekbar/ExposureBar.kt
@@ -46,12 +46,7 @@ class ExposureBar : AppCompatSeekBar {
         max = exposureState.exposureCompensationRange.upper
         min = exposureState.exposureCompensationRange.lower
 
-        incrementProgressBy(exposureState.exposureCompensationIndex)
-
-        Log.i("TAG", "Setting progress from setExposureConfig")
-        progress = (exposureState.exposureCompensationStep.numerator
-                / exposureState.exposureCompensationStep.denominator) *
-                exposureState.exposureCompensationIndex
+        progress = exposureState.exposureCompensationIndex
 
         onSizeChanged(width, height, 0, 0)
     }
@@ -109,11 +104,10 @@ class ExposureBar : AppCompatSeekBar {
             MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE, MotionEvent.ACTION_UP -> {
                 progress = max - (max * event.y / (height / 2)).toInt()
 
-                Log.i("progress", progress.toString())
-                Log.i("max", max.toString())
+                Log.d("progress", progress.toString())
+                Log.d("max", max.toString())
 
-                mainActivity.camConfig.camera?.cameraControl
-                    ?.setExposureCompensationIndex(progress)
+                updateExposureCompensationIndex(progress)
 
                 showPanel()
 
@@ -123,5 +117,14 @@ class ExposureBar : AppCompatSeekBar {
             }
         }
         return true
+    }
+
+    private fun updateExposureCompensationIndex(exposureCompensationIndex: Int) {
+        mainActivity.camConfig.camera?.cameraControl
+            ?.setExposureCompensationIndex(progress)
+
+        if (mainActivity.camConfig.persistExposureLevel) {
+            mainActivity.camConfig.exposureLevel = exposureCompensationIndex
+        }
     }
 }

--- a/app/src/main/res/drawable/exposure_icon_adaptable.xml
+++ b/app/src/main/res/drawable/exposure_icon_adaptable.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="?attr/colorControlNormal"
+      android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM6,7h5v1.5L6,8.5L6,7zM19,19L5,19L19,5v14zM14.5,16v2L16,18v-2h2v-1.5h-2v-2h-1.5v2h-2L12.5,16z"/>
+</vector>

--- a/app/src/main/res/layout/more_settings.xml
+++ b/app/src/main/res/layout/more_settings.xml
@@ -719,6 +719,81 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/misc_settings"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/TextAppearance.Material3.LabelLarge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="12dp"
+                    android:layout_marginStart="78dp"
+                    android:text="@string/misc" />
+
+                <LinearLayout
+                    android:id="@+id/persist_exposure_level_setting"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="horizontal"
+                    android:paddingTop="8dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingBottom="10dp">
+
+                    <ImageView
+                        android:id="@+id/persist_exposure_level_icon"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:contentDescription="@string/persist_exposure_level"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="8dp"
+                        android:src="@drawable/exposure_icon_adaptable" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="4dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/persist_exposure_level_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="10dp"
+                            android:paddingBottom="2dp"
+                            android:text="@string/persist_exposure_level"
+                            android:textColor="?android:textColorPrimary"
+                            android:textSize="16sp" />
+
+                        <TextView
+                            android:id="@+id/persist_exposure_level_subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="10dp"
+                            android:text="@string/persist_exposure_level_setting_description"
+                            android:textSize="14sp"
+                            tools:ignore="RtlSymmetry" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/persist_exposure_level_toggle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginStart="4dp"
+                        android:layout_marginEnd="0dp" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,8 @@
 
     <string name="video_audio_recording_muted">The video\'s audio recording has been muted</string>
     <string name="video_audio_recording_unmuted">The video\'s audio recording has been unmuted</string>
+
+    <string name="misc">Miscellaneous</string>
+    <string name="persist_exposure_level">Persist exposure level</string>
+    <string name="persist_exposure_level_setting_description">Saves the last exposure level that was set by the user</string>
 </resources>


### PR DESCRIPTION
This PR adds support for saving the last explicitly chosen exposure by the user. The option is turned off by default to let the app auto-choose the best exposure based on view the camera is currently exposed to. Resolves the issue described in #503