### PR TITLE
Replace orientation API calls with sensor calculated orientation

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -9,6 +9,7 @@ import android.provider.MediaStore
 import android.util.Log
 import android.util.Size
 import android.view.MotionEvent
+import android.view.Surface
 import android.view.View
 import android.view.animation.AlphaAnimation
 import android.view.animation.Animation
@@ -1061,17 +1062,7 @@ class CamConfig(private val mActivity: MainActivity) {
         mActivity.exposureBar.hidePanel()
         modePref = mActivity.getSharedPreferences(currentMode.name, Context.MODE_PRIVATE)
 
-        val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val display = mActivity.display
-            display?.rotation ?: @Suppress("DEPRECATION")
-            mActivity.windowManager.defaultDisplay.rotation
-        } else {
-            // We don't really have any option here, but this initialization
-            // ensures that the app doesn't break later when the below
-            // deprecated option gets removed post Android R
-            @Suppress("DEPRECATION")
-            mActivity.windowManager.defaultDisplay.rotation
-        }
+        val rotation = mActivity.sensorNotifier?.getSurfaceRotation() ?: Surface.ROTATION_0
 
         if (mActivity.isDestroyed || mActivity.isFinishing) return
 

--- a/app/src/main/java/app/grapheneos/camera/notifier/SensorOrientationChangeNotifier.kt
+++ b/app/src/main/java/app/grapheneos/camera/notifier/SensorOrientationChangeNotifier.kt
@@ -5,6 +5,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.view.Surface
 import android.view.View
 import app.grapheneos.camera.ui.activities.MainActivity
 import java.lang.ref.WeakReference
@@ -54,7 +55,7 @@ class SensorOrientationChangeNotifier private constructor(
         private const val Z_EXIT_MAX = 45F
     }
 
-    var mOrientation = mainActivity.getRotation()
+    var mOrientation = 0
         private set
 
     private val mListeners = ArrayList<WeakReference<Listener?>>(3)
@@ -70,7 +71,7 @@ class SensorOrientationChangeNotifier private constructor(
             mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
             SensorManager.SENSOR_DELAY_NORMAL
         )
-        notifyListeners(true)
+        notifyListeners()
     }
 
     /**
@@ -160,6 +161,15 @@ class SensorOrientationChangeNotifier private constructor(
         override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
     }
 
+    fun getSurfaceRotation() : Int {
+        return when(mOrientation) {
+            90 -> Surface.ROTATION_90
+            180 -> Surface.ROTATION_180
+            270 -> Surface.ROTATION_270
+            else -> Surface.ROTATION_0
+        }
+    }
+
     fun forceUpdateGyro() {
         mSensorEventListener.let {
             it.updateGyro(it.lastX, it.lastZ)
@@ -195,11 +205,7 @@ class SensorOrientationChangeNotifier private constructor(
         return null
     }
 
-    fun notifyListeners(manualUpdate: Boolean = false) {
-
-        if (manualUpdate) {
-            mOrientation = mainActivity.getRotation()
-        }
+    fun notifyListeners() {
 
         val deadLinksArr = ArrayList<WeakReference<Listener?>>()
         for (wr in mListeners) {

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -1542,30 +1542,13 @@ open class MainActivity : AppCompatActivity(),
     }
 
     fun forceUpdateOrientationSensor() {
-        sensorNotifier?.notifyListeners(true)
+        sensorNotifier?.notifyListeners()
     }
 
     val sensorNotifier: SensorOrientationChangeNotifier?
         get() {
             return SensorOrientationChangeNotifier.getInstance(this)
         }
-
-    fun getRotation(): Int {
-        val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            display?.rotation ?: @Suppress("DEPRECATION")
-            windowManager.defaultDisplay.rotation
-        } else {
-            @Suppress("DEPRECATION")
-            windowManager.defaultDisplay.rotation
-        }
-
-        return when (rotation) {
-            Surface.ROTATION_90 -> 270
-            Surface.ROTATION_180 -> 180
-            Surface.ROTATION_270 -> 90
-            else -> 0
-        }
-    }
 
     fun onDeviceAngleChange(xDegrees: Float, zDegrees: Float) {
 


### PR DESCRIPTION
The current APIs we use are deprecated/always return 0 since the orientation is fixed for main activity. The rationale behind using accelerometer to reliably calculate orientation is that gravity constantly has small impacts on the accelerometer causing it to continuously generate new values on a real device.

Indirectly fixes the issue described in #534 by only relying on sensor data to calculate orientation