### PR TITLE
Add support for mock location while geotagging

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -185,6 +185,7 @@
             android:theme="@style/Theme.App"
             android:taskAffinity=".ui.activities.InAppGallery"
             android:excludeFromRecents="true"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false"/>
 
         <activity

--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -111,6 +111,11 @@ class CamConfig(private val mActivity: MainActivity) {
 
             const val ENABLE_ZSL = "enable_zsl"
 
+            const val MOCK_LOCATION_STATE = "mock_location_state"
+
+            const val MOCK_LOCATION_LATITUDE = "mock_location_latitude"
+            const val MOCK_LOCATION_LONGITUDE = "mock_location_longitude"
+
             // const val IMAGE_FILE_FORMAT = "image_quality"
             // const val VIDEO_FILE_FORMAT = "video_quality"
         }
@@ -155,6 +160,11 @@ class CamConfig(private val mActivity: MainActivity) {
             const val CAMERA_SOUNDS = true
 
             const val ENABLE_ZSL = false
+
+            const val MOCK_LOCATION_STATE = false
+
+            const val MOCK_LOCATION_LATITUDE = 0.0f
+            const val MOCK_LOCATION_LONGITUDE = 0.0f
 
             // const val IMAGE_FILE_FORMAT = ""
             // const val VIDEO_FILE_FORMAT = ""
@@ -552,6 +562,48 @@ class CamConfig(private val mActivity: MainActivity) {
                 SettingValues.Key.GYROSCOPE_SUGGESTIONS,
                 value
             )
+            editor.apply()
+        }
+
+    var mockLocationEnabled: Boolean
+        get() {
+            return commonPref.getBoolean(
+                SettingValues.Key.MOCK_LOCATION_STATE,
+                SettingValues.Default.MOCK_LOCATION_STATE
+            )
+        }
+        set(value) {
+            val editor = commonPref.edit()
+            editor.putBoolean(
+                SettingValues.Key.MOCK_LOCATION_STATE,
+                value
+            )
+            editor.apply()
+        }
+
+    var mockLocationLatitude: Float
+        get() {
+            return commonPref.getFloat(
+                SettingValues.Key.MOCK_LOCATION_LATITUDE,
+                SettingValues.Default.MOCK_LOCATION_LATITUDE
+            )
+        }
+        set(value) {
+            val editor = commonPref.edit()
+            editor.putFloat(SettingValues.Key.MOCK_LOCATION_LATITUDE, value)
+            editor.apply()
+        }
+
+    var mockLocationLongitude: Float
+        get() {
+            return commonPref.getFloat(
+                SettingValues.Key.MOCK_LOCATION_LONGITUDE,
+                SettingValues.Default.MOCK_LOCATION_LONGITUDE
+            )
+        }
+        set(value) {
+            val editor = commonPref.edit()
+            editor.putFloat(SettingValues.Key.MOCK_LOCATION_LONGITUDE, value)
             editor.apply()
         }
 

--- a/app/src/main/java/app/grapheneos/camera/NumLimitFilter.kt
+++ b/app/src/main/java/app/grapheneos/camera/NumLimitFilter.kt
@@ -2,9 +2,15 @@ package app.grapheneos.camera
 
 import android.text.InputFilter
 import android.text.Spanned
-import app.grapheneos.camera.ui.activities.MoreSettings
 
-class NumInputFilter(private val settings: MoreSettings) : InputFilter {
+// Ensures that the field is within the min/max limits for a number type input field
+class NumLimitFilter(
+    val min: Float,
+    val max: Float,
+    val onOutOfRange: () -> Unit,
+) : InputFilter {
+
+    constructor(min: Int, max: Int, onOutOfRange: () -> Unit) : this(min.toFloat(), max.toFloat(), onOutOfRange)
 
     override fun filter(
         source: CharSequence,
@@ -18,25 +24,20 @@ class NumInputFilter(private val settings: MoreSettings) : InputFilter {
             val input = (dest.subSequence(0, dstart).toString() + source + dest.subSequence(
                 dend,
                 dest.length
-            )).toInt()
+            )).toFloat()
             if (isInRange(input)) {
                 return null
             } else {
-                settings.showMessage(settings.getString(
-                    R.string.photo_quality_number_limit, min, max))
+                this.onOutOfRange()
             }
         } catch (e: NumberFormatException) {
             e.printStackTrace()
+            return null
         }
         return ""
     }
 
-    private fun isInRange(value: Int): Boolean {
-        return value in min..max
-    }
-
-    companion object {
-        const val min = 1
-        const val max = 100
+    private fun isInRange(value: Float): Boolean {
+        return value in this.min..this.max
     }
 }

--- a/app/src/main/java/app/grapheneos/camera/capturer/ImageCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/ImageCapturer.kt
@@ -7,6 +7,7 @@ import android.app.NotificationManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.graphics.Bitmap
+import android.location.Location
 import android.os.Build
 import android.util.Log
 import android.view.View
@@ -77,7 +78,14 @@ class ImageCapturer(val mActivity: MainActivity) {
                 && camConfig.saveImageAsPreviewed
 
         if (camConfig.requireLocation) {
-            val location = (mActivity.applicationContext as App).getLocation()
+            val location = if (camConfig.mockLocationEnabled) {
+                val loc = Location("")
+                loc.latitude = camConfig.mockLocationLatitude.toDouble()
+                loc.longitude = camConfig.mockLocationLongitude.toDouble()
+                loc
+            } else {
+                (mActivity.applicationContext as App).getLocation()
+            }
             if (location == null) {
                 mActivity.showMessage(R.string.location_unavailable)
             } else {

--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -134,7 +134,15 @@ class VideoCapturer(private val mActivity: MainActivity) {
 
         var location: Location? = null
         if (camConfig.requireLocation) {
-            location = (mActivity.applicationContext as App).getLocation()
+            val location = if (camConfig.mockLocationEnabled) {
+                val loc = Location("")
+                loc.latitude = camConfig.mockLocationLatitude.toDouble()
+                loc.longitude = camConfig.mockLocationLongitude.toDouble()
+                loc
+            } else {
+                (mActivity.applicationContext as App).getLocation()
+            }
+
             if (location == null) {
                 mActivity.showMessage(R.string.location_unavailable)
             }

--- a/app/src/main/res/drawable/location.xml
+++ b/app/src/main/res/drawable/location.xml
@@ -1,35 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="false">
-        <layer-list>
-            <item>
-                <shape android:shape="oval">
-                    <solid android:color="?attr/colorSurfaceContainer"/>
-                    <padding
-                        android:left="@dimen/toggle_button_padding"
-                        android:right="@dimen/toggle_button_padding"
-                        android:top="@dimen/toggle_button_padding"
-                        android:bottom="@dimen/toggle_button_padding"/>
-                </shape>
-            </item>
-            <item
-                android:drawable="@drawable/location_off"/>
-        </layer-list>
-    </item>
-    <item android:state_checked="true">
-        <layer-list>
-            <item>
-                <shape android:shape="oval">
-                    <solid android:color="?attr/colorPrimary"/>
-                    <padding
-                        android:left="@dimen/toggle_button_padding"
-                        android:right="@dimen/toggle_button_padding"
-                        android:top="@dimen/toggle_button_padding"
-                        android:bottom="@dimen/toggle_button_padding"/>
-                </shape>
-            </item>
-            <item
-                android:drawable="@drawable/location_on"/>
-        </layer-list>
-    </item>
-</selector>
+<vector
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+
+</vector>

--- a/app/src/main/res/drawable/location_toggle.xml
+++ b/app/src/main/res/drawable/location_toggle.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="false">
+        <layer-list>
+            <item>
+                <shape android:shape="oval">
+                    <solid android:color="?attr/colorSurfaceContainer"/>
+                    <padding
+                        android:left="@dimen/toggle_button_padding"
+                        android:right="@dimen/toggle_button_padding"
+                        android:top="@dimen/toggle_button_padding"
+                        android:bottom="@dimen/toggle_button_padding"/>
+                </shape>
+            </item>
+            <item
+                android:drawable="@drawable/location_off"/>
+        </layer-list>
+    </item>
+    <item android:state_checked="true">
+        <layer-list>
+            <item>
+                <shape android:shape="oval">
+                    <solid android:color="?attr/colorPrimary"/>
+                    <padding
+                        android:left="@dimen/toggle_button_padding"
+                        android:right="@dimen/toggle_button_padding"
+                        android:top="@dimen/toggle_button_padding"
+                        android:bottom="@dimen/toggle_button_padding"/>
+                </shape>
+            </item>
+            <item
+                android:drawable="@drawable/location_on"/>
+        </layer-list>
+    </item>
+</selector>

--- a/app/src/main/res/layout/more_settings.xml
+++ b/app/src/main/res/layout/more_settings.xml
@@ -165,6 +165,118 @@
 
                 </LinearLayout>
 
+                <LinearLayout
+                    android:id="@+id/mock_location_settings"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="horizontal"
+                    android:paddingTop="8dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingBottom="10dp">
+
+                    <ImageView
+                        android:id="@+id/mock_location_setting_icon"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:contentDescription="@string/mock_location"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="8dp"
+                        android:src="@drawable/location" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="4dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/mock_location_setting_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="10dp"
+                            android:paddingBottom="4dp"
+                            android:text="@string/mock_location"
+                            android:textColor="?android:textColorPrimary"
+                            android:textSize="16sp" />
+
+                        <TextView
+                            android:id="@+id/mock_location_setting_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="10dp"
+                            android:paddingBottom="8dp"
+                            android:text="@string/mock_location_description"
+                            android:textSize="14sp"
+                            tools:ignore="RtlSymmetry" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                                android:layout_width="0dp"
+                                android:layout_weight="1"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="5dp"
+                                android:layout_marginLeft="5dp"
+                                android:layout_marginEnd="5dp"
+                                android:layout_marginRight="5dp"
+                                android:padding="3dp">
+
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/latitude_textfield"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:hint="@string/latitude"
+                                    app:suffixText="@string/degree_symbol"
+                                    android:imeOptions="actionNext"
+                                    android:nextFocusRight="@id/longitude_textfield"
+                                    android:inputType="numberDecimal|numberSigned" />
+
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                                android:layout_width="0dp"
+                                android:layout_weight="1"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="5dp"
+                                android:layout_marginLeft="5dp"
+                                android:layout_marginEnd="5dp"
+                                android:layout_marginRight="5dp"
+                                android:padding="3dp">
+
+                                <!--android:maxLength="13"-->
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/longitude_textfield"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:hint="@string/longitude"
+                                    app:suffixText="@string/degree_symbol"
+                                    android:imeOptions="actionDone"
+                                    android:inputType="numberDecimal|numberSigned" />
+
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/mock_location_setting_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="0dp" />
+
+                </LinearLayout>
+
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -48,7 +48,7 @@
                         android:textOff=""
                         android:checked="false"
                         android:layout_gravity="center"
-                        android:background="@drawable/location"
+                        android:background="@drawable/location_toggle"
                         android:text="@string/toggle_button"/>
 
                 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,14 @@
 
     <string name="video_audio_recording_muted">The video\'s audio recording has been muted</string>
     <string name="video_audio_recording_unmuted">The video\'s audio recording has been unmuted</string>
+
+    <string name="mock_location">Use Mock Location</string>
+    <string name="mock_location_description">When enabled uses below location over the location provided by device for geo-tagging</string>
+
+    <string name="degree_symbol">°</string>
+    <string name="latitude">Latitude</string>
+    <string name="longitude">Longitude</string>
+
+    <string name="latitude_number_limit">Latitude can only be between %1$.1f and %2$.1f</string>
+    <string name="longitude_number_limit">Longitude can only be between %1$.1f and %2$.1f</string>
 </resources>


### PR DESCRIPTION
This PR aims to address the feature request described in #451

It currently only supports latitude and longitude to keep things simple, but an extended UI/more fields can be added to enhance the functionality further