### PR TITLE
Add support for picking images/video in capture activities

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ktx/InputStream.kt
+++ b/app/src/main/java/app/grapheneos/camera/ktx/InputStream.kt
@@ -1,0 +1,20 @@
+package app.grapheneos.camera.ktx
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+private const val DEFAULT_BUFFER_SIZE = 0x2000
+
+// TODO: Replace calls with transferTo when minSdk becomes 33 or above
+@Throws(IOException::class)
+fun InputStream.transfer(out: OutputStream): Long {
+    var transferred: Long = 0
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var read: Int
+    while ((this.read(buffer, 0, DEFAULT_BUFFER_SIZE).also { read = it }) >= 0) {
+        out.write(buffer, 0, read)
+        transferred += read.toLong()
+    }
+    return transferred
+}

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
@@ -36,6 +36,9 @@ open class CaptureActivity : MainActivity() {
     private lateinit var retakeIcon: ImageView
 
     private lateinit var flipCameraContent: ImageView
+
+    protected var isPreviewShown = false
+
     lateinit var confirmButton: ImageButton
 
     fun isOutputUriAvailable(): Boolean {
@@ -155,6 +158,8 @@ open class CaptureActivity : MainActivity() {
 
     open fun showPreview() {
 
+        isPreviewShown = true
+
         camConfig.cameraProvider?.unbindAll()
 
         mainOverlay.setImageBitmap(bitmap)
@@ -172,6 +177,9 @@ open class CaptureActivity : MainActivity() {
     }
 
     open fun hidePreview() {
+
+        isPreviewShown = false
+
         camConfig.startCamera(true)
 
         settingsIcon.visibility = View.VISIBLE

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/CaptureActivity.kt
@@ -234,16 +234,17 @@ open class CaptureActivity : MainActivity() {
 
     private fun resizeImage(image: Bitmap): Bitmap {
 
+        // If within supported 1 megabyte size
+        if (image.byteCount <= 0x100000)
+            return image
+
         val width = image.width
         val height = image.height
 
         val scaleWidth = width / 10
         val scaleHeight = height / 10
 
-        if (image.byteCount <= 1000000)
-            return image
-
-        return Bitmap.createScaledBitmap(image, scaleWidth, scaleHeight, false)
+        return image.scale(scaleWidth, scaleHeight, false)
     }
 
     private fun Bitmap.rotate(degrees: Float): Bitmap {

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -193,6 +193,8 @@ open class MainActivity : AppCompatActivity(),
 
     lateinit var gCircleFrame: FrameLayout
 
+    lateinit var flipCameraIcon: ImageView
+
     private lateinit var gAngleTextView: TextView
     private lateinit var gCircle: LinearLayout
 
@@ -712,7 +714,6 @@ open class MainActivity : AppCompatActivity(),
                 return@setOnClickListener
             }
 
-            val flipCameraIcon: ImageView = binding.flipCameraIcon
             val rotation: Float = if (flipCameraIcon.rotation < 180) {
                 180f
             } else {
@@ -785,6 +786,8 @@ open class MainActivity : AppCompatActivity(),
                 }
             }
         }
+
+        flipCameraIcon = binding.flipCameraIcon
 
         cancelButtonView = binding.cancelButton
 //        cancelButtonView.setOnClickListener(object : View.OnClickListener {

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import android.provider.MediaStore.EXTRA_OUTPUT
 import android.view.View
 import android.widget.ImageView
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import app.grapheneos.camera.R
 
 class VideoCaptureActivity : CaptureActivity() {
@@ -14,6 +16,14 @@ class VideoCaptureActivity : CaptureActivity() {
     private lateinit var playPreview: ImageView
 
     private var savedUri: Uri? = null
+
+    private val videoPicker = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+        if (uri != null) {
+            confirmSelectedVideo(uri)
+        } else {
+            showMessage(R.string.no_video_selected)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,7 +55,7 @@ class VideoCaptureActivity : CaptureActivity() {
         playPreview.visibility = View.VISIBLE
 
         confirmButton.setOnClickListener {
-            confirmVideo()
+            confirmCapturedVideo()
         }
 
     }
@@ -66,7 +76,7 @@ class VideoCaptureActivity : CaptureActivity() {
         thirdOption.visibility = View.VISIBLE
     }
 
-    private fun confirmVideo() {
+    private fun confirmCapturedVideo() {
         if (savedUri == null) {
             setResult(RESULT_CANCELED)
         } else {
@@ -79,6 +89,15 @@ class VideoCaptureActivity : CaptureActivity() {
             )
             setResult(RESULT_OK, resultIntent)
         }
+        finish()
+    }
+
+    private fun confirmSelectedVideo(uri: Uri) {
+        val resultIntent = Intent()
+        resultIntent.data = uri
+        resultIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        resultIntent.putExtra(EXTRA_OUTPUT, uri)
+        setResult(RESULT_OK, resultIntent)
         finish()
     }
 

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
@@ -33,6 +33,19 @@ class VideoCaptureActivity : CaptureActivity() {
 
         captureButton.setImageResource(R.drawable.recording)
 
+        thirdCircle.setOnClickListener {
+            if (isPreviewShown) {
+                val i = Intent(
+                    this@VideoCaptureActivity,
+                    VideoPlayer::class.java
+                )
+                i.putExtra("videoUri", savedUri)
+                startActivity(i)
+            } else {
+                videoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly))
+            }
+        }
+
         captureButton.setOnClickListener OnClickListener@{
             if (videoCapturer.isRecording) {
                 videoCapturer.stopRecording()
@@ -41,18 +54,9 @@ class VideoCaptureActivity : CaptureActivity() {
             }
         }
 
-        playPreview.setOnClickListener {
-            val i = Intent(
-                this@VideoCaptureActivity,
-                VideoPlayer::class.java
-            )
-            i.putExtra("videoUri", savedUri)
-            startActivity(i)
-        }
-
         imagePreview.visibility = View.GONE
         whiteOptionCircle.visibility = View.GONE
-        playPreview.visibility = View.VISIBLE
+        // playPreview.visibility = View.VISIBLE
 
         confirmButton.setOnClickListener {
             confirmCapturedVideo()
@@ -74,6 +78,9 @@ class VideoCaptureActivity : CaptureActivity() {
     override fun showPreview() {
         super.showPreview()
         thirdOption.visibility = View.VISIBLE
+        selectImageIcon.visibility = View.GONE
+        playPreview.visibility = View.VISIBLE
+        thirdCircle.setImageResource(R.drawable.option_circle)
     }
 
     private fun confirmCapturedVideo() {
@@ -103,6 +110,7 @@ class VideoCaptureActivity : CaptureActivity() {
 
     override fun hidePreview() {
         super.hidePreview()
-        thirdOption.visibility = View.INVISIBLE
+        selectImageIcon.visibility = View.VISIBLE
+        playPreview.visibility = View.GONE
     }
 }

--- a/app/src/main/res/drawable/image_search.xml
+++ b/app/src/main/res/drawable/image_search.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#fff" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M18,13v7L4,20L4,6h5.02c0.05,-0.71 0.22,-1.38 0.48,-2L4,4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-5l-2,-2zM16.5,18h-11l2.75,-3.53 1.96,2.36 2.75,-3.54zM19.3,8.89c0.44,-0.7 0.7,-1.51 0.7,-2.39C20,4.01 17.99,2 15.5,2S11,4.01 11,6.5s2.01,4.5 4.49,4.5c0.88,0 1.7,-0.26 2.39,-0.7L21,13.42 22.42,12 19.3,8.89zM15.5,9C14.12,9 13,7.88 13,6.5S14.12,4 15.5,4 18,5.12 18,6.5 16.88,9 15.5,9z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -371,7 +371,7 @@
                     android:layout_height="32dp"
                     android:src="@drawable/image_search"
                     android:layout_gravity="center"
-                    android:contentDescription="@string/select_image_from_picker"
+                    android:contentDescription="@string/select_media_from_picker"
                     android:visibility="gone"/>
 
             </FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -365,6 +365,15 @@
                     android:layout_gravity="center"
                     android:contentDescription="@string/play_preview"/>
 
+                <ImageView
+                    android:id="@+id/select_image_icon"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/image_search"
+                    android:layout_gravity="center"
+                    android:contentDescription="@string/select_image_from_picker"
+                    android:visibility="gone"/>
+
             </FrameLayout>
 
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,9 @@
 
     <string name="video_audio_recording_muted">The video\'s audio recording has been muted</string>
     <string name="video_audio_recording_unmuted">The video\'s audio recording has been unmuted</string>
+
+    <string name="select_media_from_picker">Select media from picker</string>
+    <string name="no_image_selected">No image selected from picker</string>
+    <string name="no_video_selected">No video selected from picker</string>
+    <string name="unexpected_error_occurred">An unexpected error occurred</string>
 </resources>


### PR DESCRIPTION
This PR adds support for selecting image and video in respective capture activities in cases when the user might want to select an image directly from the camera itself