### PR TITLE
Support beginning a video recording with the microphone muted

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -1145,6 +1145,12 @@ class CamConfig(private val mActivity: MainActivity) {
                     } else {
                         View.VISIBLE
                     }
+                mActivity.muteToggle.visibility =
+                    if (includeAudio) {
+                        View.VISIBLE
+                    } else {
+                        View.GONE
+                    }
 
                 val videoCaptureBuilder = VideoCapture.Builder(
                     Recorder.Builder()
@@ -1426,8 +1432,6 @@ class CamConfig(private val mActivity: MainActivity) {
 
             mActivity.captureButton.setBackgroundResource(android.R.color.transparent)
             mActivity.captureButton.setImageResource(R.drawable.torch_off_button)
-
-            mActivity.micOffIcon.visibility = View.GONE
         } else {
             mActivity.qrOverlay.visibility = View.INVISIBLE
             mActivity.thirdOption.visibility = View.VISIBLE
@@ -1442,10 +1446,11 @@ class CamConfig(private val mActivity: MainActivity) {
                 mActivity.captureButton.setImageResource(R.drawable.recording)
             } else {
                 mActivity.captureButton.setImageResource(R.drawable.camera_shutter)
-                mActivity.micOffIcon.visibility = View.GONE
             }
         }
 
+        mActivity.micOffIcon.visibility = View.GONE
+        mActivity.muteToggle.visibility = View.GONE
         mActivity.cbText.visibility = if (isQRMode || isVideoMode || mActivity.timerDuration == 0) {
             View.INVISIBLE
         } else {

--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -187,7 +187,7 @@ class VideoCapturer(private val mActivity: MainActivity) {
         val pendingRecording = recordingCtx.pendingRecording
 
         if (includeAudio) {
-            pendingRecording.withAudioEnabled()
+            pendingRecording.withAudioEnabled(isMuted)
         }
 
         beforeRecordingStarts()
@@ -315,14 +315,6 @@ class VideoCapturer(private val mActivity: MainActivity) {
         mActivity.timerView.visibility = View.VISIBLE
 
         mActivity.settingsDialog.includeAudioToggle.isEnabled = false
-
-        if (camConfig.includeAudio) {
-            isMuted = false
-            mActivity.muteToggle.setImageResource(R.drawable.mic_on)
-            mActivity.muteToggle.setBackgroundColor(mActivity.getColor(R.color.red))
-            mActivity.muteToggle.tooltipText = mActivity.getString(R.string.tap_to_mute_audio)
-            mActivity.muteToggle.visibility = View.VISIBLE
-        }
     }
 
     private fun afterRecordingStops() {
@@ -375,7 +367,6 @@ class VideoCapturer(private val mActivity: MainActivity) {
         //   mActivity.micOffIcon.visibility = View.VISIBLE
 
         mActivity.settingsDialog.includeAudioToggle.isEnabled = true
-        mActivity.muteToggle.visibility = View.GONE
 
         isRecording = false
 
@@ -383,14 +374,12 @@ class VideoCapturer(private val mActivity: MainActivity) {
     }
 
     fun muteRecording() {
-        if (!isRecording) return
         check(camConfig.includeAudio)
         isMuted = true
         recording?.mute(true)
     }
 
     fun unmuteRecording() {
-        if (!isRecording) return
         check(camConfig.includeAudio)
         isMuted = false
         recording?.mute(false)

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -369,6 +369,11 @@ class SettingsDialog(val mActivity: MainActivity, themedContext: Context) :
             } else {
                 View.VISIBLE
             }
+            mActivity.muteToggle.visibility = if (includeAudioToggle.isChecked) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
 
             camConfig.includeAudio = includeAudioToggle.isChecked
         }

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
@@ -64,6 +64,7 @@ class VideoCaptureActivity : CaptureActivity() {
     override fun showPreview() {
         super.showPreview()
         thirdOption.visibility = View.VISIBLE
+        muteToggle.visibility = View.GONE
     }
 
     private fun confirmVideo() {


### PR DESCRIPTION
Now that the app is using CameraX 1.5, it is possible to set an initial muted state when recording a video. This PR makes it so that the microphone mute icon displays at all times in video mode, unless the Include Audio toggle is disabled.

Unlike Include Audio, this setting does not persist. This makes it useful as a quicker way to disable audio for a one-off recording or to start a recording muted and unmute audio only at a later time.

One downside compared to disabling Include Audio is that an audio track is always included regardless of whether the microphone was ever unmuted (it will be completely silent if muted for the entire recording). For videos meant to not have any audio, this uses additional storage and might display differently in some players, so I don't think this should replace the Include Audio toggle.