### PR TITLE
Correctly hide mic off icon in video capture mode

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/VideoCaptureActivity.kt
@@ -64,6 +64,7 @@ class VideoCaptureActivity : CaptureActivity() {
     override fun showPreview() {
         super.showPreview()
         thirdOption.visibility = View.VISIBLE
+        micOffIcon.visibility = View.GONE
     }
 
     private fun confirmVideo() {


### PR DESCRIPTION
Fixes UI issue with mic off icon being visible over the confirm tick after finishing a recording in video capture activity