### PR TITLE
Add support for preview inversion

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -1215,6 +1215,17 @@ class CamConfig(private val mActivity: MainActivity) {
             previewBuilder.setPreviewStabilizationEnabled(false)
         }
 
+        // Adapt
+        if ((lensFacing == CameraSelector.LENS_FACING_FRONT) && (isVideoMode && saveVideoAsPreviewed) || (isInPhotoMode && saveImageAsPreviewed)) {
+            previewBuilder.setMirrorMode(
+                MirrorMode.MIRROR_MODE_ON
+            )
+        } else {
+            previewBuilder.setMirrorMode(
+                MirrorMode.MIRROR_MODE_OFF
+            )
+        }
+
         preview = previewBuilder.build().also {
             useCaseGroupBuilder.addUseCase(it)
             it.setSurfaceProvider(mActivity.previewView.surfaceProvider)

--- a/app/src/main/res/layout/more_settings.xml
+++ b/app/src/main/res/layout/more_settings.xml
@@ -65,7 +65,7 @@
                         android:id="@+id/gyroscope_setting_icon"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:contentDescription="@string/save_image_as_previewed"
+                        android:contentDescription="@string/fix_inversion_for_photos"
                         android:paddingStart="4dp"
                         android:paddingEnd="8dp"
                         android:src="@drawable/straighten" />
@@ -257,7 +257,7 @@
                         android:id="@+id/save_image_as_preview_icon"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:contentDescription="@string/save_image_as_previewed"
+                        android:contentDescription="@string/fix_inversion_for_photos"
                         android:paddingStart="4dp"
                         android:paddingEnd="8dp"
                         android:src="@drawable/selfie_preview" />
@@ -275,7 +275,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginStart="10dp"
                             android:paddingBottom="2dp"
-                            android:text="@string/save_image_as_previewed"
+                            android:text="@string/fix_inversion_for_photos"
                             android:textColor="?android:textColorPrimary"
                             android:textSize="16sp" />
 
@@ -284,7 +284,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingStart="10dp"
-                            android:text="@string/save_as_image_preview_desc"
+                            android:text="@string/fix_inversion_for_photos_desc"
                             android:textSize="14sp"
                             tools:ignore="RtlSymmetry" />
 
@@ -399,7 +399,7 @@
                         android:id="@+id/remove_exif_icon"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:contentDescription="@string/save_image_as_previewed"
+                        android:contentDescription="@string/fix_inversion_for_photos"
                         android:paddingStart="4dp"
                         android:paddingEnd="8dp"
                         android:src="@drawable/info_adaptable" />
@@ -473,7 +473,7 @@
                         android:id="@+id/save_video_as_preview_icon"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:contentDescription="@string/save_video_as_previewed"
+                        android:contentDescription="@string/fix_inversion_for_videos"
                         android:paddingStart="4dp"
                         android:paddingEnd="8dp"
                         android:src="@drawable/selfie_preview" />
@@ -491,7 +491,7 @@
                             android:layout_height="wrap_content"
                             android:layout_marginStart="10dp"
                             android:paddingBottom="2dp"
-                            android:text="@string/save_video_as_previewed"
+                            android:text="@string/fix_inversion_for_videos"
                             android:textColor="?android:textColorPrimary"
                             android:textSize="16sp" />
 
@@ -500,7 +500,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:paddingStart="10dp"
-                            android:text="@string/save_as_video_preview_desc"
+                            android:text="@string/fix_inversion_for_videos_desc"
                             android:textSize="14sp"
                             tools:ignore="RtlSymmetry" />
 
@@ -547,7 +547,7 @@
                         android:id="@+id/storage_location_icon"
                         android:layout_width="48dp"
                         android:layout_height="48dp"
-                        android:contentDescription="@string/save_image_as_previewed"
+                        android:contentDescription="@string/fix_inversion_for_photos"
                         android:paddingStart="4dp"
                         android:paddingEnd="8dp"
                         android:src="@drawable/storage" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,11 +69,11 @@
 
     <string name="general">General</string>
 
-    <string name="save_image_as_previewed">Save image as previewed</string>
-    <string name="save_as_image_preview_desc">Save output image as visible on preview (fixes inversion in front camera)</string>
+    <string name="fix_inversion_for_photos">Fix front camera inversion</string>
+    <string name="fix_inversion_for_photos_desc">Fixes inversion while taking a photo via the front camera</string>
 
-    <string name="save_video_as_previewed">Save video as previewed</string>
-    <string name="save_as_video_preview_desc">Save output video as visible on preview (fixes inversion in front camera)</string>
+    <string name="fix_inversion_for_videos">Fix front camera inversion</string>
+    <string name="fix_inversion_for_videos_desc">Fixes inversion while recording a video via the front camera</string>
 
     <string name="gyroscope_suggestions">Gyroscope Suggestions</string>
     <string name="gyroscope_setting_desc">Occasionally get visual suggestions for straight/well-angled images</string>


### PR DESCRIPTION
This PR tries to resolve issue #497. It includes preview inversion support for existing save image/video as previewed toggle as renames them to "Fix inversion of camera" toggle for photo and video individually. Unifying it further might need us to get away with the existing toggles/preferences