### PR TITLE
Fix the crash in CameraX 1.5.0-rc01 with video mode

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -1158,8 +1158,6 @@ class CamConfig(private val mActivity: MainActivity) {
                     .build()
                 )
 
-                videoCaptureBuilder.setVideoStabilizationEnabled(mActivity.camConfig.enableEIS)
-
                 if (mActivity.camConfig.saveVideoAsPreviewed)
                     videoCaptureBuilder.setMirrorMode(MirrorMode.MIRROR_MODE_ON_FRONT_ONLY)
 
@@ -1214,12 +1212,6 @@ class CamConfig(private val mActivity: MainActivity) {
             .setResolutionSelector(
                 ResolutionSelector.Builder().setAspectRatioStrategy(aspectRatioStrategy).build()
             )
-
-        if (isVideoMode && isPreviewStabilizationSupported()) {
-            previewBuilder.setPreviewStabilizationEnabled(enableEIS)
-        } else {
-            previewBuilder.setPreviewStabilizationEnabled(false)
-        }
 
         preview = previewBuilder.build().also {
             useCasesList.add(it)


### PR DESCRIPTION
CameraX version 1.5.0-rc01 forces a crash when video stabilization is set through both GroupableFeature (in SessionConfig API) and the existing UseCases API (via VideoCaptureBuilder/PreviewBuilder). 

We require the functionality present in GroupableFeature therefore we stick to using that and comment out the other usages to prevent any crash