### PR TITLE
Handle cases when preloaded media item gets removed

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/InAppGallery.kt
@@ -594,7 +594,10 @@ class InAppGallery : AppCompatActivity() {
             val adapterItems = existingAdapter.items
             adapterItems.ensureCapacity(items.size)
 
-            val preloadedItem = adapterItems[0]
+            // At times the first item could get deleted before the others get
+            // loaded especially on relatively slower devices, allowing null without throwing
+            // an exception enables handling of such scenarios
+            val preloadedItem = adapterItems.getOrNull(0)
 
             items.forEachIndexed { index, item ->
                 // this check is needed to avoid showing preloaded item twice (it's not guaranteed


### PR DESCRIPTION
This PR aims to fix crashes in cases where deleting a preloaded item before all the other images are loaded, causes the in app gallery activity to crash