### PR TITLE
Update Material library to version 1.13.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,7 +91,7 @@ android {
 
 dependencies {
     implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("com.google.android.material:material:1.12.0")
+    implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
     implementation("androidx.core:core-ktx:1.17.0")
 

--- a/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/SettingsDialog.kt
@@ -89,7 +89,7 @@ class SettingsDialog(val mActivity: MainActivity, themedContext: Context) :
     private var moreSettingsButton: View
 
     private val tabSelectedColor =
-        MaterialColors.getColor(binding.root, com.google.android.material.R.attr.colorPrimary)
+        MaterialColors.getColor(binding.root, androidx.appcompat.R.attr.colorPrimary)
 
     private fun getString(@StringRes id: Int) = mActivity.getString(id)
 


### PR DESCRIPTION
Changes in this PR include:

- Upgrade to the latest 1.13.0 for the material library
- Directly using android appcompat's color resource instead of using it via material component library (as the library currently enables non-transitive dependency checks, which helps in preventing duplication of resource for optimization)