### PR TITLE
Allow limiting photo resolution

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/capturer/ImageSaver.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/ImageSaver.kt
@@ -3,6 +3,7 @@ package app.grapheneos.camera.capturer
 import android.annotation.SuppressLint
 import android.content.ContentValues
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.graphics.ImageFormat
 import android.graphics.Rect
@@ -38,7 +39,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
 
 // see com.android.externalstorage.ExternalStorageProvider and
 // com.android.internal.content.FileSystemProvider

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -382,6 +382,40 @@
                         </FrameLayout>
                     </LinearLayout>
 
+                    <LinearLayout
+                        android:id="@+id/capture_resolution_setting"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/settings_dialog_menu_item_height"
+                        android:paddingVertical="@dimen/settings_dialog_menu_item_vertical"
+                        android:paddingHorizontal="@dimen/settings_dialog_menu_item_horizontal"
+                        android:layout_gravity="end"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_height="wrap_content"
+                            android:layout_width="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:text="@string/capture_resolution"/>
+
+                        <FrameLayout
+                            android:layout_height="wrap_content"
+                            android:padding="0dp"
+                            android:layout_margin="0dp"
+                            android:layout_width="match_parent">
+
+                            <Spinner
+                                android:id="@+id/capture_resolution_spinner"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:checked="true"
+                                android:padding="0dp"
+                                android:layout_margin="0dp"
+                                android:layout_gravity="end"/>
+
+                        </FrameLayout>
+                    </LinearLayout>
+
                     <!-- Extra padding for the bottom of the list -->
                     <View
                         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="self_illumination">Self Illumination</string>
     <string name="focus_timeout">Focus Timeout</string>
     <string name="timer">Timer</string>
+    <string name="capture_resolution">Capture Resolution</string>
     <string name="cancel_timer">Cancel Timer</string>
     <string name="video_capture_label">Record Video</string>
 


### PR DESCRIPTION
Often I don't need a photo at maximum resolution. To efficiently use disk space, it's helpful to be able to limit the pixel size of the longest edge.

![screenshot](https://github.com/user-attachments/assets/2829e01c-a4f1-4520-9099-5bac3c138fc6)
