### PR TITLE
fix inverted accuracy check in getOptimalLocation()

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/App.kt
+++ b/app/src/main/java/app/grapheneos/camera/App.kt
@@ -100,8 +100,9 @@ class App : Application() {
                     optimalLocation = location
                 } else {
                     // Compare their accuracy instead of time if the difference is below
-                    // threshold
-                    if (location.accuracy > optimalLocation.accuracy) {
+                    // threshold. Location.getAccuracy() is a radius in meters, so a
+                    // smaller value means a more accurate fix.
+                    if (location.accuracy < optimalLocation.accuracy) {
                         optimalLocation = location
                     }
                 }


### PR DESCRIPTION
`Location.getAccuracy()` is a radius in meters, smaller is better but `getOptimalLocation()` used `>` in its accuracy tiebreaker, so when two fixes arrived within `STALE_LOCATION_THRESHOLD` (11 s) the *less* accurate one replaced the more accurate one.

The selected `Location` is attached as EXIF GPS data on captured photos and as video metadata when "Save location" is enabled, so the bug silently degrades geotag quality (e.g. a ~500 m network fix overwriting a ~5 m GNSS fix). 