### PR TITLE
When copying to clipboard qr scan result show an UI feedback

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -1198,17 +1198,29 @@ open class MainActivity : AppCompatActivity(),
             })
 
             val ctc: ImageButton = dialogBinding.copyQrText
+            val confirmationLabel = dialogBinding.copyConfirmation
+
             ctc.setOnClickListener {
-                val clipboardManager = getSystemService(
-                    Context.CLIPBOARD_SERVICE
-                ) as ClipboardManager
-                val clipData = ClipData.newPlainText(
-                    "text",
-                    textView.text
-                )
+                val clipboardManager = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                val clipData = ClipData.newPlainText("text", textView.text)
                 clipboardManager.setPrimaryClip(clipData)
 
-                showMessage(getString(R.string.copied_text_to_clipboard))
+                ctc.setImageResource(R.drawable.ic_check)
+                ctc.imageTintList = null
+                ctc.animate().scaleX(1.2f).scaleY(1.2f).setDuration(100).withEndAction {
+                    ctc.animate().scaleX(1.0f).scaleY(1.0f).setDuration(100)
+                }
+                    confirmationLabel.visibility = View.VISIBLE
+                    confirmationLabel.postDelayed({
+                        confirmationLabel.visibility = View.GONE
+                    }, 2000)
+
+                ctc.postDelayed({
+                    ctc.animate().alpha(0f).setDuration(150).withEndAction {
+                        ctc.setImageResource(R.drawable.copy_to_clipboard)
+                        ctc.animate().alpha(1f).setDuration(150).start()
+                    }
+                }, 2000)
             }
 
             val sButton: ImageButton = dialogBinding.shareQrText

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="?attr/colorPrimary"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/scan_result_dialog.xml
+++ b/app/src/main/res/layout/scan_result_dialog.xml
@@ -84,4 +84,19 @@
         android:layout_width="match_parent"
         android:textColor="?android:attr/textColorPrimary"/>
 
+    <TextView
+        android:id="@+id/copy_confirmation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:padding="10dp"
+        android:text="@string/copied_text_to_clipboard"
+        android:backgroundTint="?attr/colorSecondaryContainer"
+        android:background="@drawable/qr_result_background"
+        android:textColor="?attr/colorOnSecondaryContainer"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:visibility="gone" />
+
 </LinearLayout>


### PR DESCRIPTION
To avoid duplicate notifications and to follow android guidelines for the copy to clipboard this PR disable the snackbar when user copy the QR scan result on Android 13 and upper and keep it for Android 12 and lower.

Closes https://github.com/GrapheneOS/Camera/issues/619