### PR TITLE
add hold shutter to record video in photo mode

### DIFF
--- a/app/src/main/java/app/grapheneos/camera/CamConfig.kt
+++ b/app/src/main/java/app/grapheneos/camera/CamConfig.kt
@@ -113,6 +113,8 @@ class CamConfig(private val mActivity: MainActivity) {
 
             const val CAMERA_SOUNDS = "camera_sounds"
 
+            const val QUICK_VIDEO_HOLD = "quick_video_hold"
+
             const val ENABLE_ZSL = "enable_zsl"
 
             const val SELECT_HIGHEST_RESOLUTION = "select_highest_resolution"
@@ -159,6 +161,8 @@ class CamConfig(private val mActivity: MainActivity) {
             const val GYROSCOPE_SUGGESTIONS = false
 
             const val CAMERA_SOUNDS = true
+
+            const val QUICK_VIDEO_HOLD = true
 
             const val ENABLE_ZSL = false
 
@@ -297,6 +301,9 @@ class CamConfig(private val mActivity: MainActivity) {
 
     private var currentMode: CameraMode = DEFAULT_CAMERA_MODE
 
+    val mode: CameraMode
+        get() = currentMode
+
     var aspectRatio: Int
         get() {
             return when {
@@ -407,6 +414,19 @@ class CamConfig(private val mActivity: MainActivity) {
         set(value) {
             val editor = commonPref.edit()
             editor.putBoolean(SettingValues.Key.CAMERA_SOUNDS, value)
+            editor.apply()
+        }
+
+    var quickVideoHold: Boolean
+        get() {
+            return commonPref.getBoolean(
+                SettingValues.Key.QUICK_VIDEO_HOLD,
+                SettingValues.Default.QUICK_VIDEO_HOLD
+            )
+        }
+        set(value) {
+            val editor = commonPref.edit()
+            editor.putBoolean(SettingValues.Key.QUICK_VIDEO_HOLD, value)
             editor.apply()
         }
 
@@ -759,6 +779,13 @@ class CamConfig(private val mActivity: MainActivity) {
 
         if (!commonPref.contains(SettingValues.Key.CAMERA_SOUNDS)) {
             editor.putBoolean(SettingValues.Key.CAMERA_SOUNDS, SettingValues.Default.CAMERA_SOUNDS)
+        }
+
+        if (!commonPref.contains(SettingValues.Key.QUICK_VIDEO_HOLD)) {
+            editor.putBoolean(
+                SettingValues.Key.QUICK_VIDEO_HOLD,
+                SettingValues.Default.QUICK_VIDEO_HOLD
+            )
         }
 
         // Note: This is a workaround to keep save image/video as previewed 'on' by 

--- a/app/src/main/java/app/grapheneos/camera/capturer/QuickVideoController.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/QuickVideoController.kt
@@ -1,0 +1,125 @@
+package app.grapheneos.camera.capturer
+
+import app.grapheneos.camera.CameraMode
+import app.grapheneos.camera.ui.activities.CaptureActivity
+import app.grapheneos.camera.ui.activities.MainActivity
+
+class QuickVideoController(private val mActivity: MainActivity) {
+
+    private val camConfig get() = mActivity.camConfig
+    private val videoCapturer get() = mActivity.videoCapturer
+
+    private var pressActive = false
+    private var startPending = false
+    private var sourceMode: CameraMode? = null
+    private var hardwareKeyCode: Int? = null
+
+    val isEngaged: Boolean
+        get() = startPending || sourceMode != null
+
+    private val isEligible: Boolean
+        get() = mActivity !is CaptureActivity
+                && !mActivity.requiresVideoModeOnly
+                && !camConfig.isVideoMode
+                && !camConfig.isQRMode
+                && camConfig.quickVideoHold
+                && mActivity.timerDuration == 0
+                && !videoCapturer.isRecording
+
+    fun onPressDown() {
+        pressActive = true
+    }
+
+    fun start(): Boolean {
+        pressActive = true
+        if (!isEligible) {
+            pressActive = false
+            return false
+        }
+
+        sourceMode = camConfig.mode
+        startPending = true
+
+        camConfig.switchMode(CameraMode.VIDEO)
+        startIfPending()
+        return true
+    }
+
+    fun startFromHardwareKey(keyCode: Int): Boolean {
+        if (!start()) {
+            return false
+        }
+        hardwareKeyCode = keyCode
+        return true
+    }
+
+    fun onCameraReady() {
+        startIfPending()
+    }
+
+    fun release(): Boolean {
+        pressActive = false
+
+        if (startPending) {
+            startPending = false
+            restoreSourceMode()
+            return true
+        }
+
+        val source = sourceMode ?: return false
+
+        if (videoCapturer.isRecording) {
+            videoCapturer.stopRecording {
+                if (sourceMode == source) {
+                    restoreSourceMode()
+                }
+            }
+        } else {
+            restoreSourceMode()
+        }
+
+        return true
+    }
+
+    fun onHardwareKeyRelease(keyCode: Int): Boolean {
+        if (hardwareKeyCode != keyCode) {
+            return false
+        }
+        hardwareKeyCode = null
+        return release()
+    }
+
+    fun reset() {
+        pressActive = false
+        startPending = false
+        sourceMode = null
+        hardwareKeyCode = null
+    }
+
+    private fun startIfPending() {
+        if (!startPending || !camConfig.isVideoMode) {
+            return
+        }
+        startPending = false
+
+        if (!pressActive) {
+            restoreSourceMode()
+            return
+        }
+
+        videoCapturer.startRecording(forceAudio = true)
+        if (!videoCapturer.isRecording) {
+            restoreSourceMode()
+        }
+    }
+
+    private fun restoreSourceMode() {
+        val source = sourceMode ?: return
+        sourceMode = null
+        startPending = false
+
+        if (!videoCapturer.isRecording && camConfig.mode != source) {
+            camConfig.switchMode(source)
+        }
+    }
+}

--- a/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
+++ b/app/src/main/java/app/grapheneos/camera/capturer/VideoCapturer.kt
@@ -49,6 +49,8 @@ class VideoCapturer(private val mActivity: MainActivity) {
     private val videoFileFormat = ".mp4"
 
     private var recording: Recording? = null
+    private var onFinalizeCallback: (() -> Unit)? = null
+    private var forceAudioOnNextStart = false
 
     var isMuted = false
         private set
@@ -149,7 +151,11 @@ class VideoCapturer(private val mActivity: MainActivity) {
         return null
     }
 
-    fun startRecording() {
+    fun startRecording(forceAudio: Boolean = false) {
+        if (forceAudio) {
+            forceAudioOnNextStart = true
+        }
+
         if (camConfig.camera == null) return
         val recorder = camConfig.videoCapture?.output ?: return
         if (isRecording) return
@@ -161,8 +167,9 @@ class VideoCapturer(private val mActivity: MainActivity) {
         includeAudio = false
 
         val ctx = mActivity
+        val shouldIncludeAudio = forceAudioOnNextStart || ctx.settingsDialog.includeAudioToggle.isChecked
 
-        if (ctx.settingsDialog.includeAudioToggle.isChecked) {
+        if (shouldIncludeAudio) {
             if (ctx.checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PERMISSION_GRANTED) {
                 includeAudio = true
             } else {
@@ -171,6 +178,7 @@ class VideoCapturer(private val mActivity: MainActivity) {
                 return
             }
         }
+        forceAudioOnNextStart = false
 
         val recordingCtx = try {
             createRecordingContext(recorder, fileName)!!
@@ -205,6 +213,9 @@ class VideoCapturer(private val mActivity: MainActivity) {
                 }
 
                 if (event is VideoRecordEvent.Finalize) {
+                    val finalizeCallback = onFinalizeCallback
+                    onFinalizeCallback = null
+
                     afterRecordingStops()
 
                     camConfig.mPlayer.playVRStopSound()
@@ -213,12 +224,14 @@ class VideoCapturer(private val mActivity: MainActivity) {
                         when (event.error) {
                             VideoRecordEvent.Finalize.ERROR_NO_VALID_DATA -> {
                                 ctx.showMessage(R.string.recording_too_short_to_be_saved)
+                                finalizeCallback?.invoke()
                                 return@start
                             }
                             VideoRecordEvent.Finalize.ERROR_ENCODING_FAILED,
                             VideoRecordEvent.Finalize.ERROR_RECORDER_ERROR,
                             VideoRecordEvent.Finalize.ERROR_UNKNOWN -> {
                                 ctx.showMessage(ctx.getString(R.string.unable_to_save_video_verbose, event.error))
+                                finalizeCallback?.invoke()
                                 return@start
                             }
                             else -> {
@@ -251,6 +264,8 @@ class VideoCapturer(private val mActivity: MainActivity) {
                     if (ctx is VideoCaptureActivity) {
                         ctx.afterRecording(uri)
                     }
+
+                    finalizeCallback?.invoke()
                 }
             }
 
@@ -394,10 +409,15 @@ class VideoCapturer(private val mActivity: MainActivity) {
         recording?.mute(false)
     }
 
-    fun stopRecording() {
+    fun stopRecording(onStopped: (() -> Unit)? = null) {
+        onFinalizeCallback = onStopped
         recording?.stop()
         recording?.close()
         recording = null
+    }
+
+    fun clearForceAudioForNextStart() {
+        forceAudioOnNextStart = false
     }
 }
 

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -71,6 +71,7 @@ import app.grapheneos.camera.ITEM_TYPE_IMAGE
 import app.grapheneos.camera.ITEM_TYPE_VIDEO
 import app.grapheneos.camera.R
 import app.grapheneos.camera.capturer.ImageCapturer
+import app.grapheneos.camera.capturer.QuickVideoController
 import app.grapheneos.camera.capturer.VideoCapturer
 import app.grapheneos.camera.capturer.getVideoThumbnail
 import app.grapheneos.camera.databinding.ActivityMainBinding
@@ -247,6 +248,7 @@ open class MainActivity : AppCompatActivity(),
     lateinit var micOffIcon: ImageView
 
     private var shouldRestartRecording = false
+    private val quickVideo = QuickVideoController(this)
 
     fun startFocusTimer() {
         handler.postDelayed(runnable, autoCenterFocusDuration)
@@ -265,6 +267,7 @@ open class MainActivity : AppCompatActivity(),
             return@registerForActivityResult
         }
         showAudioPermissionDeniedDialog {
+            videoCapturer.clearForceAudioForNextStart()
             videoCapturer.startRecording()
         }
     }
@@ -508,6 +511,10 @@ open class MainActivity : AppCompatActivity(),
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        if (quickVideo.onHardwareKeyRelease(keyCode)) {
+            return true
+        }
+
         // there are no camera controls in qr mode
         if (camConfig.isQRMode) {
             return super.onKeyUp(keyCode, event)
@@ -536,10 +543,22 @@ open class MainActivity : AppCompatActivity(),
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+            if (event?.repeatCount == 0) {
+                event.startTracking()
+            }
             // Pretend as if the event was handled by the app (avoid volume bar from appearing)
             return true
         }
         return super.onKeyDown(keyCode, event)
+    }
+
+    override fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+            quickVideo.startFromHardwareKey(keyCode)
+            return true
+        }
+
+        return super.onKeyLongPress(keyCode, event)
     }
 
     override fun onResume() {
@@ -659,6 +678,7 @@ open class MainActivity : AppCompatActivity(),
                 }
 
                 restartRecordingIfPermissionsWasUnavailable()
+                quickVideo.onCameraReady()
             } else {
                 previewGrid.visibility = View.INVISIBLE
                 val lastFrame = lastFrame
@@ -756,7 +776,30 @@ open class MainActivity : AppCompatActivity(),
         }
 
         captureButton = binding.captureButton
+        captureButton.setOnLongClickListener {
+            quickVideo.start()
+        }
+        captureButton.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    quickVideo.onPressDown()
+                }
+
+                MotionEvent.ACTION_UP,
+                MotionEvent.ACTION_CANCEL -> {
+                    if (quickVideo.release()) {
+                        return@setOnTouchListener true
+                    }
+                }
+            }
+
+            false
+        }
         captureButton.setOnClickListener {
+            if (quickVideo.isEngaged) {
+                return@setOnClickListener
+            }
+
             resetAutoSleep()
             if (camConfig.isVideoMode) {
                 if (videoCapturer.isRecording) {
@@ -1776,6 +1819,7 @@ open class MainActivity : AppCompatActivity(),
     override fun onStop() {
         super.onStop()
         isStarted = false
+        quickVideo.reset()
         if (this::videoCapturer.isInitialized && videoCapturer.isRecording) {
             videoCapturer.stopRecording()
         }

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MoreSettings.kt
@@ -204,6 +204,17 @@ open class MoreSettings : AppCompatActivity(), TextView.OnEditorActionListener {
             csSwitch.performClick()
         }
 
+        val qvhSwitch = binding.quickVideoHoldSwitch
+        qvhSwitch.isChecked = camConfig.quickVideoHold
+        qvhSwitch.setOnClickListener {
+            camConfig.quickVideoHold = qvhSwitch.isChecked
+        }
+
+        val qvhSetting = binding.quickVideoHoldSetting
+        qvhSetting.setOnClickListener {
+            qvhSwitch.performClick()
+        }
+
         val sIAPSetting = binding.saveImageAsPreviewSetting
         sIAPSetting.setOnClickListener {
             sIAPToggle.performClick()

--- a/app/src/main/res/layout/more_settings.xml
+++ b/app/src/main/res/layout/more_settings.xml
@@ -165,6 +165,64 @@
 
                 </LinearLayout>
 
+                <LinearLayout
+                    android:id="@+id/quick_video_hold_setting"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="horizontal"
+                    android:paddingTop="8dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingBottom="10dp">
+
+                    <ImageView
+                        android:id="@+id/quick_video_hold_icon"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:contentDescription="@string/quick_video_hold"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="8dp"
+                        android:src="@drawable/play" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="4dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/quick_video_hold_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="10dp"
+                            android:paddingBottom="2dp"
+                            android:text="@string/quick_video_hold"
+                            android:textColor="?android:textColorPrimary"
+                            android:textSize="16sp" />
+
+                        <TextView
+                            android:id="@+id/quick_video_hold_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="10dp"
+                            android:text="@string/quick_video_hold_desc"
+                            android:textSize="14sp"
+                            tools:ignore="RtlSymmetry" />
+
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/quick_video_hold_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="0dp" />
+
+                </LinearLayout>
+
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
 
     <string name="camera_sounds">Camera Sounds</string>
     <string name="camera_sounds_desc">Shutter sound and other audio cues</string>
+    <string name="quick_video_hold">Hold shutter for video</string>
+    <string name="quick_video_hold_desc">Press and hold the shutter button or volume keys in photo mode to record a video until release.</string>
 
     <string name="storage">Storage</string>
     <string name="storage_location">Storage Location</string>


### PR DESCRIPTION
This adds a Samsung-style quick video capture in photo mode. Press and hold the shutter button or a volume key to start recording, and release to stop. A short tap still takes a photo as before. Audio is always captured for these clips and the existing recording timer and button are reused. It can be turned off from a new toggle in More settings and is on by default.

The quick video logic lives in a small QuickVideoController so the changes to MainActivity stay minimal, and the on-screen button and the volume keys go through the same path.

This was developed with LLM assistance and extensively tested by Konty on a Galaxy A26 and a Pixel 8a.
