### PR TITLE
fix geotagging location selection, providers, lifecycle and staleness

### DIFF
--- a/app/src/androidTest/java/app/grapheneos/camera/LocationSelectionTest.kt
+++ b/app/src/androidTest/java/app/grapheneos/camera/LocationSelectionTest.kt
@@ -1,0 +1,94 @@
+package app.grapheneos.camera
+
+import android.location.Location
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class LocationSelectionTest {
+
+    private val baseNanos = TimeUnit.SECONDS.toNanos(10_000)
+
+    private fun location(elapsedMs: Long, accuracy: Float? = null) =
+        Location("test").apply {
+            elapsedRealtimeNanos = baseNanos + TimeUnit.MILLISECONDS.toNanos(elapsedMs)
+            if (accuracy != null) {
+                this.accuracy = accuracy
+            }
+        }
+
+    @Test
+    fun returnsNullForEmptyList() {
+        assertNull(getOptimalLocation(emptyList()))
+    }
+
+    @Test
+    fun returnsNullWhenEveryElementIsNull() {
+        assertNull(getOptimalLocation(listOf(null, null)))
+    }
+
+    @Test
+    fun ignoresNullElements() {
+        val only = location(elapsedMs = 0, accuracy = 5f)
+        assertSame(only, getOptimalLocation(listOf(null, only, null)))
+    }
+
+    @Test
+    fun prefersTheMoreAccurateFixWithinTheThreshold() {
+        val accurate = location(elapsedMs = 0, accuracy = 5f)
+        val newerButCoarser = location(elapsedMs = 5_000, accuracy = 50f)
+        assertSame(accurate, getOptimalLocation(listOf(accurate, newerButCoarser)))
+    }
+
+    @Test
+    fun prefersTheNewerFixWhenAccuracyIsEqual() {
+        val older = location(elapsedMs = 0, accuracy = 10f)
+        val newer = location(elapsedMs = 5_000, accuracy = 10f)
+        assertSame(newer, getOptimalLocation(listOf(older, newer)))
+    }
+
+    @Test
+    fun prefersTheNewerFixBeyondTheThresholdEvenIfLessAccurate() {
+        val accurate = location(elapsedMs = 0, accuracy = 5f)
+        val muchNewerButCoarse = location(elapsedMs = 12_000, accuracy = 500f)
+        assertSame(muchNewerButCoarse, getOptimalLocation(listOf(accurate, muchNewerButCoarse)))
+    }
+
+    @Test
+    fun treatsAFixWithoutAccuracyAsLeastAccurate() {
+        val withoutAccuracy = location(elapsedMs = 1_000, accuracy = null)
+        val withAccuracy = location(elapsedMs = 0, accuracy = 100f)
+        assertSame(withAccuracy, getOptimalLocation(listOf(withoutAccuracy, withAccuracy)))
+    }
+
+    @Test
+    fun doesNotSelectAnAccurateFixThatIsStaleRelativeToTheNewest() {
+        // The newest fix (c) pulls the freshness window forward: a is now too old
+        // to compete, so the choice is the more accurate of the in-window b and c.
+        val a = location(elapsedMs = 0, accuracy = 5f)
+        val b = location(elapsedMs = 10_000, accuracy = 50f)
+        val c = location(elapsedMs = 21_000, accuracy = 300f)
+        assertSame(b, getOptimalLocation(listOf(a, b, c)))
+    }
+
+    @Test
+    fun doesNotDependOnTheOrderOfTheCandidates() {
+        val a = location(elapsedMs = 0, accuracy = 5f)
+        val b = location(elapsedMs = 10_000, accuracy = 50f)
+        val c = location(elapsedMs = 21_000, accuracy = 300f)
+        val fromForward = getOptimalLocation(listOf(a, b, c))
+        val fromReversed = getOptimalLocation(listOf(c, b, a))
+        assertSame(fromForward, fromReversed)
+    }
+
+    @Test
+    fun treatsAFixExactlyAtTheThresholdAsWithinTheWindow() {
+        val accurateOlder = location(elapsedMs = 0, accuracy = 5f)
+        val newer = location(elapsedMs = 11_000, accuracy = 50f)
+        assertSame(accurateOlder, getOptimalLocation(listOf(accurateOlder, newer)))
+    }
+}

--- a/app/src/main/java/app/grapheneos/camera/App.kt
+++ b/app/src/main/java/app/grapheneos/camera/App.kt
@@ -12,7 +12,6 @@ import android.view.WindowManager
 import androidx.annotation.RequiresPermission
 import androidx.appcompat.app.AppCompatActivity
 import app.grapheneos.camera.capturer.deleteStalePendingRecordings
-import app.grapheneos.camera.ktx.isSystemApp
 import app.grapheneos.camera.ui.activities.MainActivity
 import com.google.android.material.color.DynamicColors
 import kotlin.concurrent.thread
@@ -98,17 +97,14 @@ class App : Application() {
         }
         isLocationFetchInProgress = true
 
-        val providers = if (applicationInfo.isSystemApp() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            listOf<String>(LocationManager.FUSED_PROVIDER)
-        } else {
-            locationManager.allProviders
-        }
+        val providers = locationProviders
+
         val lastKnownLocations = providers.map {
             locationManager.getLastKnownLocation(it)
         }
         location = getOptimalLocation(lastKnownLocations + location)
 
-        locationManager.allProviders.forEach { provider ->
+        providers.forEach { provider ->
             locationManager.requestLocationUpdates(
                 provider,
                 2000,
@@ -117,6 +113,20 @@ class App : Application() {
             )
         }
     }
+
+    private val locationProviders: List<String>
+        get() {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                locationManager.hasProvider(LocationManager.FUSED_PROVIDER)
+            ) {
+                return listOf(LocationManager.FUSED_PROVIDER)
+            }
+            return locationManager.allProviders.filter {
+                it == LocationManager.GPS_PROVIDER ||
+                    it == LocationManager.NETWORK_PROVIDER ||
+                    it == LocationManager.PASSIVE_PROVIDER
+            }
+        }
 
     fun dropLocationUpdates() {
         isLocationFetchInProgress = false

--- a/app/src/main/java/app/grapheneos/camera/App.kt
+++ b/app/src/main/java/app/grapheneos/camera/App.kt
@@ -19,10 +19,6 @@ import kotlin.concurrent.thread
 
 class App : Application() {
 
-    companion object {
-        private const val STALE_LOCATION_THRESHOLD = 11 * 1000L
-    }
-
     private var activity: MainActivity? = null
     private var location: Location? = null
 
@@ -35,7 +31,7 @@ class App : Application() {
     private val locationListener: LocationListener by lazy {
         object : LocationListener {
             override fun onLocationChanged(changedLocation: Location) {
-                location = listOf(location, changedLocation).getOptimalLocation()
+                location = getOptimalLocation(listOf(location, changedLocation))
             }
 
             override fun onProviderDisabled(provider: String) {
@@ -45,10 +41,7 @@ class App : Application() {
             }
 
             override fun onLocationChanged(locations: MutableList<Location>) {
-                val location = locations.getOptimalLocation()
-                if (location != null) {
-                    this@App.location = location
-                }
+                location = getOptimalLocation(locations + location)
             }
 
             override fun onProviderEnabled(provider: String) {}
@@ -84,34 +77,6 @@ class App : Application() {
         return false
     }
 
-    fun List<Location?>.getOptimalLocation(): Location? {
-        if (isNullOrEmpty()) return null
-
-        var optimalLocation: Location? = null
-        forEach { location ->
-            if (location != null) {
-                if (optimalLocation == null) {
-                    optimalLocation = location
-                    return@forEach
-                }
-
-                val timeDifference = location.time - optimalLocation.time
-
-                // If the location is older than STALE_LOCATION_THRESHOLD ms
-                if (timeDifference > STALE_LOCATION_THRESHOLD) {
-                    optimalLocation = location
-                } else {
-                    // Compare their accuracy instead of time if the difference is below
-                    // threshold
-                    if (location.accuracy > optimalLocation.accuracy) {
-                        optimalLocation = location
-                    }
-                }
-            }
-        }
-        return optimalLocation
-    }
-
     override fun onCreate() {
         super.onCreate()
         registerActivityLifecycleCallbacks(activityLifeCycleHelper)
@@ -132,20 +97,16 @@ class App : Application() {
             dropLocationUpdates()
         }
         isLocationFetchInProgress = true
-        if (location == null) {
-            val providers = if (applicationInfo.isSystemApp() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                listOf<String>(LocationManager.FUSED_PROVIDER)
-            } else {
-                locationManager.allProviders
-            }
-            val locations = providers.map {
-                locationManager.getLastKnownLocation(it)
-            }
-            val fetchedLocation = locations.getOptimalLocation()
-            if (fetchedLocation != null) {
-                location = fetchedLocation
-            }
+
+        val providers = if (applicationInfo.isSystemApp() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            listOf<String>(LocationManager.FUSED_PROVIDER)
+        } else {
+            locationManager.allProviders
         }
+        val lastKnownLocations = providers.map {
+            locationManager.getLastKnownLocation(it)
+        }
+        location = getOptimalLocation(lastKnownLocations + location)
 
         locationManager.allProviders.forEach { provider ->
             locationManager.requestLocationUpdates(

--- a/app/src/main/java/app/grapheneos/camera/App.kt
+++ b/app/src/main/java/app/grapheneos/camera/App.kt
@@ -8,15 +8,22 @@ import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Build
 import android.os.CountDownTimer
+import android.os.SystemClock
 import android.view.WindowManager
 import androidx.annotation.RequiresPermission
 import androidx.appcompat.app.AppCompatActivity
 import app.grapheneos.camera.capturer.deleteStalePendingRecordings
 import app.grapheneos.camera.ui.activities.MainActivity
 import com.google.android.material.color.DynamicColors
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
 class App : Application() {
+
+    companion object {
+        // Must stay above the ~10 min throttle the OS applies to coarse-only apps.
+        private const val MAX_LOCATION_AGE = 15 * 60 * 1000L
+    }
 
     private var activity: MainActivity? = null
     private var location: Location? = null
@@ -108,7 +115,7 @@ class App : Application() {
             locationManager.requestLocationUpdates(
                 provider,
                 2000,
-                10f,
+                0f,
                 locationListener
             )
         }
@@ -138,7 +145,17 @@ class App : Application() {
         location = null
     }
 
-    fun getLocation(): Location? = location
+    fun getLocation(): Location? {
+        val location = this.location ?: return null
+        val ageMs = TimeUnit.NANOSECONDS.toMillis(
+            SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos
+        )
+        if (ageMs > MAX_LOCATION_AGE) {
+            this.location = null
+            return null
+        }
+        return location
+    }
 
     private fun isLocationEnabled(): Boolean = locationManager.isLocationEnabled
 

--- a/app/src/main/java/app/grapheneos/camera/App.kt
+++ b/app/src/main/java/app/grapheneos/camera/App.kt
@@ -133,6 +133,11 @@ class App : Application() {
         locationManager.removeUpdates(locationListener)
     }
 
+    fun disableLocationFetching() {
+        dropLocationUpdates()
+        location = null
+    }
+
     fun getLocation(): Location? = location
 
     private fun isLocationEnabled(): Boolean = locationManager.isLocationEnabled

--- a/app/src/main/java/app/grapheneos/camera/LocationSelection.kt
+++ b/app/src/main/java/app/grapheneos/camera/LocationSelection.kt
@@ -1,0 +1,23 @@
+package app.grapheneos.camera
+
+import android.location.Location
+import java.util.concurrent.TimeUnit
+
+private const val STALE_LOCATION_THRESHOLD = 11 * 1000L
+
+fun getOptimalLocation(locations: List<Location?>): Location? {
+    val candidates = locations.filterNotNull()
+
+    // Order by the monotonic clock; getTime() is wall-clock and can jump.
+    val newest = candidates.maxByOrNull { it.elapsedRealtimeNanos } ?: return null
+
+    return candidates.filter {
+        val ageDifferenceMs =
+            TimeUnit.NANOSECONDS.toMillis(newest.elapsedRealtimeNanos - it.elapsedRealtimeNanos)
+        ageDifferenceMs <= STALE_LOCATION_THRESHOLD
+    }.minWithOrNull(
+        // getAccuracy() is a radius in meters, so smaller is better.
+        compareBy<Location> { if (it.hasAccuracy()) it.accuracy else Float.MAX_VALUE }
+            .thenByDescending { it.elapsedRealtimeNanos }
+    )
+}

--- a/app/src/main/java/app/grapheneos/camera/ktx/ApplicationInfo.kt
+++ b/app/src/main/java/app/grapheneos/camera/ktx/ApplicationInfo.kt
@@ -1,7 +1,0 @@
-package app.grapheneos.camera.ktx
-
-import android.content.pm.ApplicationInfo
-
-fun ApplicationInfo.isSystemApp() : Boolean {
-    return (flags and ApplicationInfo.FLAG_SYSTEM) != 0
-}

--- a/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
+++ b/app/src/main/java/app/grapheneos/camera/ui/activities/MainActivity.kt
@@ -589,6 +589,9 @@ open class MainActivity : AppCompatActivity(),
         } else {
             imageCapturer.cancelPendingCaptureRequest()
         }
+        if (camConfig.requireLocation) {
+            application.dropLocationUpdates()
+        }
         lastFrame = null
     }
 
@@ -1698,7 +1701,7 @@ open class MainActivity : AppCompatActivity(),
         if (required) {
             requestLocation()
         } else {
-            application.dropLocationUpdates()
+            application.disableLocationFetching()
         }
     }
 


### PR DESCRIPTION
Follow-up to #637 and the remaining part of #530. The one-line fix in #637 was incomplete on its own: with the comparison direction corrected, the one-sided staleness check still lets a significantly older but accurate fix win whenever it appears after a fresher one in a candidate list (last known location scans, batched updates), and the wall-clock time comparison it relies on isn't reliable across providers in the first place.

1. **Pick the most accurate recent location for geotagging instead of the least accurate one**: the accuracy tiebreaker was inverted (smaller `getAccuracy()` is better), the staleness check was one-sided (a significantly *older* candidate fell through to the accuracy comparison, making the result order-dependent), and ages were compared via wall-clock `Location.getTime()`, which the platform documentation says "should not be used to order or compare locations". The selection is now: take the newest fix (by `elapsedRealtimeNanos`), and among fixes not significantly older than it, pick the most accurate; missing accuracy ranks last, ties go to the newer fix. It lives in its own file as a plain top-level `getOptimalLocation(locations)` with instrumented tests covering the ordering, staleness, missing-accuracy and threshold-boundary cases. This commit also stops discarding the stored fix: both the batched update callback and the last known location scan now merge it into the selection instead of replacing or skipping it.

2. **Request location from the fused provider alone instead of every provider at once**: previously updates were requested from every provider at once (gps, network, fused, passive), duplicating what fused already combines and forcing the GNSS engine on. The system-app gate from #531 is replaced with `hasProvider(FUSED_PROVIDER)`: availability is the OS's contract, not the caller's privilege. Falls back to gps, network and passive before S, or on the off chance fused is absent on a newer release.

3. **Stop location updates while the activity is paused**: the listener used to stay registered for the process lifetime; now it follows onResume/onPause, and disabling geotagging clears the stored fix.

4. **Stop attaching stale locations to captures**: `getLocation()` returns null for fixes older than 15 minutes, and drops the stored fix so it can't be reused, instead of silently writing an arbitrarily old position into EXIF; the existing location-unavailable message covers that case. `minDistance` goes from 10 m to 0 so stationary users keep receiving fixes (otherwise a still-valid fix ages past any bound).